### PR TITLE
Edited FeedUrl attribute definition to use a TEXT column type instead…

### DIFF
--- a/feedme/records/FeedMe_FeedRecord.php
+++ b/feedme/records/FeedMe_FeedRecord.php
@@ -12,7 +12,7 @@ class FeedMe_FeedRecord extends BaseRecord
     {
         return array(
             'name'              => array(AttributeType::String, 'required' => true),
-            'feedUrl'           => array(AttributeType::Uri, 'required' => true),
+            'feedUrl'           => array(AttributeType::Uri, 'required' => true, 'column' => ColumnType::Text),
             'feedType'          => array(AttributeType::Enum, 'required' => true, 'values' => array(
                 FeedMe_FeedType::XML,
                 FeedMe_FeedType::RSS,


### PR DESCRIPTION
… of VARCHAR column type to support URLs over 255 characters.

I ran into an issue where I was pulling in from Facebook using a long auth token, making the URL greater than 255 characters. It seems probably that this could happen to others.

Awesome plugin - thanks!