### PR TITLE
Update confusing "duplication" terminology to "import strategy"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Enter the required details to configure your feed:
 - Set the Feed Type to assist with mapping the correct elements.
 - The Primary Element reflects which node in the feed your data sits.
 - Select the Section and Entry Type for where you want to put the feed data.
-- Decide how you'd like to handle duplicate feed items (if you're going to be re-running this feed).
+- Decide on an import strategy: how you'd like to handle duplicate feed items (if you're going to be re-running this feed).
 
 <img src="https://raw.githubusercontent.com/engram-design/FeedMe/master/screenshots/mapping_1.png" />
 
@@ -110,11 +110,13 @@ For troubleshooting, ensure you have completed the Rebuild Search Indexes task.
 We plan to include options for whether you would like to do this on a per-field basis.
 
 
-### Duplication Handling
+### Import strategy
 
 When running the feed task multiple times, there may or may not be the same data present in the feed as the last time you ran the task. To deal with this, you can control what happens to old (and new) entries when the feed is processed again.
 
 You may choose multiple fields to determine if an entry is a duplicate. Most commonly, you'll want to compare the `Title` field, but can be any fields you require.
+
+#### Strategy options:
 
 **Add Entries:**
 

--- a/feedme/templates/feeds/_edit.html
+++ b/feedme/templates/feeds/_edit.html
@@ -117,11 +117,11 @@
         <hr>
 
         {{ forms.selectField({
-            label: "Duplicate Entry Action <span class='info'><span style='display:inline-block;'><strong>Add Entries:</strong> Duplicate entries will be skipped, new entries however, will be added. <em>\"I want to keep existing entries untouched but add new ones.\"</em></span><span style='display:inline-block;'><strong>Update Entries:</strong> Select fields to compare duplicate entries with, updating all other fields.<em>\"I want to update existing entries and add new ones.\"</em></span><span style='display:inline-block;'><strong>Delete Entries:</strong> Delete all existing entries in this section, adding only entries from this feed. Be careful.<em>\"I want only the entries from this feed in this section.\"</em></span></span>" | t,
+            label: "Import strategy <span class='info'><span style='display:inline-block;'><strong>Add Entries:</strong> Duplicate entries will be skipped, new entries however, will be added. <em>\"I want to keep existing entries untouched but add new ones.\"</em></span><span style='display:inline-block;'><strong>Update Entries:</strong> Select fields to compare duplicate entries with, updating all other fields.<em>\"I want to update existing entries and add new ones.\"</em></span><span style='display:inline-block;'><strong>Delete Entries:</strong> Delete all existing entries in this section, adding only entries from this feed. Be careful.<em>\"I want only the entries from this feed in this section.\"</em></span></span>" | t,
             instructions: 'Choose how to handle duplicate records.',
             id: 'duplicateHandle',
             name: 'duplicateHandle',
-            options: {'add': 'Add Entries', 'update': 'Update Entries', 'delete': 'Delete Entries'},
+            options: {'add': 'Add Unique Entries Only', 'update': 'Add and Update Entries', 'delete': 'Delete all and Replace Entries (CAUTION)'},
             value: feed.duplicateHandle,
             required: true,
         }) }}


### PR DESCRIPTION
Update "duplication handling" terminology within UI and docs to reflect it's full purpose of "import strategy"

I found this very confusing, even after reading the docs. It's not semantically correct in places, but still hard to name.. some suggestions here.