### PR TITLE
Moved `postForFieldType` call, added $entry param

### DIFF
--- a/feedme/services/FeedMeService.php
+++ b/feedme/services/FeedMeService.php
@@ -121,9 +121,6 @@ class FeedMeService extends BaseApplicationComponent
             }
         }
 
-        // Any post-processing on our nice collection of entry-ready data.
-        craft()->feedMe_fields->postForFieldType($fieldData);
-
         $existingEntry = $criteria->first();
 
 
@@ -165,6 +162,9 @@ class FeedMeService extends BaseApplicationComponent
         //
 
         if ($canSaveEntry && $entry) {
+
+            // Any post-processing on our nice collection of entry-ready data.
+            craft()->feedMe_fields->postForFieldType($fieldData, $entry);
 
             // Prepare Element model (the default stuff)
             $entry = craft()->feedMe_entry->prepForElementModel($fieldData, $entry);

--- a/feedme/services/FeedMe_FieldsService.php
+++ b/feedme/services/FeedMe_FieldsService.php
@@ -479,7 +479,7 @@ class FeedMe_FieldsService extends BaseApplicationComponent
     // Some post-processing needs to be done, specifically for a Matrix field. Unfortuntely, multiple 
     // blocks are added out of order, which is messy - fix this here. Fortuntely, we have a 'order' attribute
     // on each block. Also call any third-party post processing (looking at you Super Table).
-    public function postForFieldType(&$fieldData)
+    public function postForFieldType(&$fieldData, $element)
     {
         // This is less intensive than craft()->fields->getFieldByHandle($fieldHandle);
         /*foreach ($fieldData as $fieldHandle => $data) {
@@ -504,7 +504,7 @@ class FeedMe_FieldsService extends BaseApplicationComponent
         }*/
 
         // Third-party fieldtype support
-        craft()->plugins->call('postForFeedMeFieldType', array(&$fieldData));
+        craft()->plugins->call('postForFeedMeFieldType', array(&$fieldData, $element));
     }
 
 }


### PR DESCRIPTION
This PR accomplishes two things...

1. The `postForFeedMeFieldType` hook is called slightly later. This ensures that a valid EntryModel has been established before the hook gets called.

2. The EntryModel is now passed into the hook as a second parameter. This allows the hook to read existing data from the Entry.