### PR TITLE
Set a user agent on the curl request

### DIFF
--- a/feedme/services/FeedMe_FeedService.php
+++ b/feedme/services/FeedMe_FeedService.php
@@ -195,6 +195,7 @@ class FeedMe_FeedService extends BaseApplicationComponent
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($curl, CURLOPT_USERAGENT, craft()->plugins->getPlugin('feedMe')->getName());
         $response = curl_exec($curl);
 
         if (!$response) {


### PR DESCRIPTION
- This is to prevent a 403 error in case the webserver hosting the xml checks whether a useragent is set and denies requests where the useragent is empty or a known spam bot.