### PR TITLE
Replace deprecated getBuild with getVersion

### DIFF
--- a/feedme/FeedMePlugin.php
+++ b/feedme/FeedMePlugin.php
@@ -94,7 +94,7 @@ class FeedMePlugin extends BasePlugin
     public function onBeforeInstall()
     {   
         // Craft 2.3.2636 fixed an issue with BaseEnum::getConstants()
-        if (version_compare(craft()->getVersion() . '.' . craft()->getBuild(), '2.3.2636', '<')) {
+        if (version_compare(craft()->getVersion() . '.' . craft()->getVersion(), '2.3.2636', '<')) {
             throw new Exception($this->getName() . ' requires Craft CMS 2.3.2636+ in order to run.');
         }
     }


### PR DESCRIPTION
Replace deprecated craft()->getBuild() with updated craft()->getVersion()

Updated versions of Craft CMS log a deprecation error with getBuild()