### PR TITLE
Add support for actually utilising custom Feed Me Data Types.

### DIFF
--- a/feedme/FeedMe/DataTypes/AtomFeedMeDataType.php
+++ b/feedme/FeedMe/DataTypes/AtomFeedMeDataType.php
@@ -1,0 +1,7 @@
+<?php
+namespace Craft;
+
+class AtomFeedMeDataType extends XmlFeedMeDataType
+{
+	// Same as XML data type.
+}

--- a/feedme/FeedMe/DataTypes/BaseFeedMeDataType.php
+++ b/feedme/FeedMe/DataTypes/BaseFeedMeDataType.php
@@ -6,9 +6,17 @@ abstract class BaseFeedMeDataType
     // Public Methods
     // =========================================================================
 
+    public function getDisplayName()
+    {
+        return StringHelper::toUpperCase($this->getDataType());
+    }
+
     public function getDataType()
     {
-        return str_replace(array('Craft\\', 'FeedMeDataType'), array('', ''), get_class($this));
+        // The data type is the short name of the class minus the 'FeedMeDataType' suffix.
+        $shortName = substr(strrchr(get_class($this), '\\'), 1);
+
+        return str_replace('FeedMeDataType', '', $shortName);
     }
 
 

--- a/feedme/FeedMe/DataTypes/RssFeedMeDataType.php
+++ b/feedme/FeedMe/DataTypes/RssFeedMeDataType.php
@@ -1,0 +1,7 @@
+<?php
+namespace Craft;
+
+class RssFeedMeDataType extends XmlFeedMeDataType
+{
+	// Same as XML data type.
+}

--- a/feedme/FeedMePlugin.php
+++ b/feedme/FeedMePlugin.php
@@ -129,7 +129,9 @@ class FeedMePlugin extends BasePlugin
     public function registerFeedMeDataTypes()
     {
         return array(
+            new AtomFeedMeDataType(),
             new JsonFeedMeDataType(),
+            new RssFeedMeDataType(),
             new XmlFeedMeDataType(),
         );
     }
@@ -173,5 +175,5 @@ class FeedMePlugin extends BasePlugin
             new UsersFeedMeFieldType(),
         );
     }
- 
+
 }

--- a/feedme/controllers/FeedMe_FeedsController.php
+++ b/feedme/controllers/FeedMe_FeedsController.php
@@ -15,6 +15,7 @@ class FeedMe_FeedsController extends BaseController
     public function actionFeedsIndex()
     {
         $variables['feeds'] = craft()->feedMe_feeds->getFeeds();
+        $variables['feedTypes'] = craft()->feedMe->getRegisteredDataTypesDisplayNames();
 
         $this->renderTemplate('feedme/feeds/index', $variables);
     }
@@ -29,6 +30,8 @@ class FeedMe_FeedsController extends BaseController
                 $variables['feed']->passkey = StringHelper::randomString(10);
             }
         }
+
+        $variables['feedTypes'] = craft()->feedMe->getRegisteredDataTypesDisplayNames(' Feed');
 
         $this->renderTemplate('feedme/feeds/_edit', $variables);
     }
@@ -57,7 +60,7 @@ class FeedMe_FeedsController extends BaseController
         $variables['task'] = $this->_runImportTask($feed->id);
 
         if (craft()->request->getParam('direct')) {
-            // If the user triggers this from the control panel (maybe for testing), triggering a task immediately will 
+            // If the user triggers this from the control panel (maybe for testing), triggering a task immediately will
             // lock up the browser session while it runs. In that case, we use JS to trigger the task (in _direct template)
             //
             // However, when triggering via Cron, run the task immediately, as Cron doesn't trigger JS (there's no browser)
@@ -123,7 +126,7 @@ class FeedMe_FeedsController extends BaseController
         craft()->end();
     }
 
-    
+
 
 
 
@@ -148,7 +151,7 @@ class FeedMe_FeedsController extends BaseController
             // Create the import task
             craft()->tasks->createTask('FeedMe', $feed->name, $settings);
 
-            // if not using the direct param for this request, do UI stuff 
+            // if not using the direct param for this request, do UI stuff
             craft()->userSession->setNotice(Craft::t('Feed processing started.'));
         }
 
@@ -207,19 +210,19 @@ class FeedMe_FeedsController extends BaseController
         if (craft()->request->getPost('fieldMapping')) {
             $feed->fieldMapping = craft()->request->getPost('fieldMapping');
         }
-        
+
         if (craft()->request->getPost('fieldDefaults')) {
             $feed->fieldDefaults = craft()->request->getPost('fieldDefaults');
         }
-        
+
         if (craft()->request->getPost('fieldElementMapping')) {
             $feed->fieldElementMapping = craft()->request->getPost('fieldElementMapping');
         }
-        
+
         if (craft()->request->getPost('fieldElementDefaults')) {
             $feed->fieldElementDefaults = craft()->request->getPost('fieldElementDefaults');
         }
-        
+
         if (craft()->request->getPost('fieldUnique')) {
             $feed->fieldUnique = craft()->request->getPost('fieldUnique');
         }
@@ -258,7 +261,7 @@ class FeedMe_FeedsController extends BaseController
         elseif (strpos($user_agent, 'Safari')) return 'Safari';
         elseif (strpos($user_agent, 'Firefox')) return 'Firefox';
         elseif (strpos($user_agent, 'MSIE') || strpos($user_agent, 'Trident/7')) return 'Internet Explorer';
-        
+
         return 'Other';
     }
 

--- a/feedme/migrations/m170224_000000_feedMe_supportCustomDataTypes.php
+++ b/feedme/migrations/m170224_000000_feedMe_supportCustomDataTypes.php
@@ -1,0 +1,12 @@
+<?php
+namespace Craft;
+
+class m170224_000000_feedMe_supportCustomDataTypes extends BaseMigration
+{
+	public function safeUp()
+	{
+		craft()->db->createCommand()->alterColumn('feedme_feeds', 'feedType', ColumnType::Varchar);
+
+		return true;
+	}
+}

--- a/feedme/models/FeedMe_FeedModel.php
+++ b/feedme/models/FeedMe_FeedModel.php
@@ -25,12 +25,7 @@ class FeedMe_FeedModel extends BaseModel
             'id'                => AttributeType::Number,
             'name'              => AttributeType::String,
             'feedUrl'           => AttributeType::Uri,
-            'feedType'          => array(AttributeType::Enum, 'values' => array(
-                FeedMe_FeedType::XML,
-                FeedMe_FeedType::RSS,
-                FeedMe_FeedType::ATOM,
-                FeedMe_FeedType::JSON,
-            )),
+            'feedType'          => AttributeType::String,
             'primaryElement'    => AttributeType::String,
             'elementType'       => AttributeType::String,
             'elementGroup'      => AttributeType::Mixed,
@@ -48,4 +43,3 @@ class FeedMe_FeedModel extends BaseModel
 }
 
 
-  

--- a/feedme/records/FeedMe_FeedRecord.php
+++ b/feedme/records/FeedMe_FeedRecord.php
@@ -13,12 +13,7 @@ class FeedMe_FeedRecord extends BaseRecord
         return array(
             'name'              => array(AttributeType::String, 'required' => true),
             'feedUrl'           => array(AttributeType::Uri, 'required' => true, 'column' => ColumnType::Text),
-            'feedType'          => array(AttributeType::Enum, 'required' => true, 'values' => array(
-                FeedMe_FeedType::XML,
-                FeedMe_FeedType::RSS,
-                FeedMe_FeedType::ATOM,
-                FeedMe_FeedType::JSON,
-            )),
+            'feedType'          => array(AttributeType::String, 'required' => true),
             'primaryElement'    => array(AttributeType::String),
             'elementType'       => array(AttributeType::String, 'required' => true),
             'elementGroup'      => array(AttributeType::Mixed),

--- a/feedme/services/FeedMeService.php
+++ b/feedme/services/FeedMeService.php
@@ -43,20 +43,10 @@ class FeedMeService extends BaseApplicationComponent
 
     public function getDataTypeService($dataType)
     {
-        // RSS/Atom use XML
-        $dataType = ($dataType == 'rss' || $dataType == 'atom') ? 'xml' : $dataType;
+        $dataTypes = $this->getRegisteredDataTypes();
 
-        // Check for third-party data type support
-        $dataToLoad = craft()->plugins->call('registerFeedMeDataTypes');
-
-        foreach ($dataToLoad as $plugin => $dataClasses) {
-            foreach ($dataClasses as $dataClass) {
-                if ($dataClass && $dataClass instanceof BaseFeedMeDataType) {
-                    if (StringHelper::toLowercase($dataClass->getDataType()) == $dataType) {
-                        return $dataClass;
-                    }
-                }
-            }
+        if (isset($dataTypes[$dataType])) {
+            return $dataTypes[$dataType];
         }
 
         return false;
@@ -80,6 +70,46 @@ class FeedMeService extends BaseApplicationComponent
         // Return default handling for a field
         return new DefaultFeedMeFieldType();
     }
-    
+
+    /**
+     * @return BaseFeedMeDataType[]
+     */
+    public function getRegisteredDataTypes()
+    {
+        $dataTypes = [];
+
+        // Check for third-party data type support
+        $dataToLoad = craft()->plugins->call('registerFeedMeDataTypes');
+
+        foreach ($dataToLoad as $plugin => $dataClasses) {
+            foreach ($dataClasses as $dataClass) {
+                if ($dataClass && $dataClass instanceof BaseFeedMeDataType) {
+                    $dataType = $dataClass->getDataType();
+
+                    $dataTypes[StringHelper::toLowerCase($dataType)] = $dataClass;
+                }
+            }
+        }
+
+        return $dataTypes;
+    }
+
+    /**
+     * @param string $suffix Optional suffix for each display name.
+	 *
+     * @return array
+     */
+    public function getRegisteredDataTypesDisplayNames($suffix = '')
+    {
+        $displayNames = [];
+
+        $dataTypes = craft()->feedMe->getRegisteredDataTypes();
+
+        foreach ($dataTypes as $dataType => $dataTypeClass) {
+            $displayNames[$dataType] = $dataTypeClass->getDisplayName() . $suffix;
+        }
+
+        return $displayNames;
+    }
 
 }

--- a/feedme/templates/feeds/_edit.html
+++ b/feedme/templates/feeds/_edit.html
@@ -49,7 +49,7 @@
         instructions: 'Choose what type of feed you\'re retrieving.' | t,
         id: 'feedType',
         name: 'feedType',
-        options: {'xml': 'XML Feed', 'rss': 'RSS Feed', 'atom': 'ATOM Feed', 'json': 'JSON Feed'},
+        options: feedTypes,
         value: feed.feedType,
         errors: feed.getErrors('feedType'),
         required: true,

--- a/feedme/templates/feeds/index.html
+++ b/feedme/templates/feeds/index.html
@@ -38,7 +38,7 @@
                 <tr data-id="{{ feed.id }}" data-name="{{ feed.name | t }}">
                     <td>{{ feed.id }}</td>
                     <td><a href="{{ url('feedme/feeds/' ~ feed.id) }}">{{ feed.name | t }}</a></td>
-                    <td>{{ feed.feedType | upper }}</td>
+                    <td>{{ (feedTypes[feed.feedType] is defined) ? feedTypes[feed.feedType] : feed.feedType|upper }}</td>
                     <td>{{ feed.feedUrl }}</td>
                     <td>{{ feed.elementType }}</td>
 


### PR DESCRIPTION
Josh,

While doing some experimenting with Feed Me, I needed to create a custom data type but then could not work out how I could actually create a feed with that custom data type. There was no built in way to select my custom data type for a new feed even though it was registered using the ```registerFeedMeDataTypes``` plugin hook. It would also not be possible to save a new feed with a custom data type, since the feeds record is restricted to your built in types.

So I went about making some changes to properly support custom Feed Me Data Types. Take a look and see what you think.

Note that I added the functionality to allow specifying a different display name for a custom data type so that the default displayed name of _MyPlugin_MyCustomFeedMeDataType_ can be customised. 

Let me know if you have any questions or recommendations.