### PR TITLE
Return empty array if variant matched w/o product

### DIFF
--- a/feedme/FeedMe/ElementTypes/Commerce_ProductFeedMeElementType.php
+++ b/feedme/FeedMe/ElementTypes/Commerce_ProductFeedMeElementType.php
@@ -83,6 +83,10 @@ class Commerce_ProductFeedMeElementType extends BaseFeedMeElementType
                     if (isset($variants[0])) {
                         $criteria->id = $variants[0]->productId;
                     }
+                    else {
+                        // otherwise we haven't found a variant but we're looking for one, so let's an empty array
+                        return array();
+                    }
                 } else {
                     $feedValue = Hash::get($data, $handle . '.data', $data[$handle]);
                     $criteria->$handle = DbHelper::escapeParam($feedValue);


### PR DESCRIPTION
Fixes #205 

`matchExistingElement` for Commerce Products has the following problem: 

If you have the unique identifier set as a Variant attribute, it searches for a Variant with that attribute, and if it finds a variant, it grabs the variant's Product and attaches that ID to the criteria. This is good.

The problem is, if we haven't found a variant, that means we have no matches, and we need to return `[]`. There might be a better way to do this rather than returning an empty array - I'm not sure. But if you don't attach anything to the criteria, it is just returning everything. This seems to solve the problem.