### PR TITLE
Fix regex to handle node names that end in digit

### DIFF
--- a/feedme/services/FeedMe_DataService.php
+++ b/feedme/services/FeedMe_DataService.php
@@ -42,7 +42,7 @@ class FeedMe_DataService extends BaseApplicationComponent
         // as some nodes don't exist on the first primary element, but do throughout the feed.
         foreach (Hash::flatten($dataArray, '/') as $nodePath => $value) {
             $feedPath = preg_replace('/(\/\d+\/)/', '/', $nodePath);
-            $feedPath = preg_replace('/(\d+\/)|(\/\d+)/', '', $feedPath);
+            $feedPath = preg_replace('/^(\d+\/)|(\/\d+)/', '', $feedPath);
 
             // The above is used to normalise repeatable nodes. Paths to nodes will look similar to:
             // 0.Assets.Asset.0.Img.0 - we want to change this to Assets/Asset/Img, This is mostly

--- a/feedme/services/FeedMe_ProcessService.php
+++ b/feedme/services/FeedMe_ProcessService.php
@@ -355,6 +355,7 @@ class FeedMe_ProcessService extends BaseApplicationComponent
             $feedPath = str_replace('.', '/', $nodePath);
             $feedPath = preg_replace('/(\/\d+\/)/', '/', $feedPath);
             $feedPath = preg_replace('/(\/\d+)|(\d+\/)/', '', $feedPath);
+            $feedPath = preg_replace('/(\/\d+)|^(\d+\/)/', '', $feedPath);
 
             // Get the feed value using dot-notation (but specifically for a node)
             $value = Hash::get($feedData, $nodePath);


### PR DESCRIPTION
I have a JSON feed with a few nodes that end with a digit. Regex was stripping them out.

`
"images": [
    {
        "cellLandscape_x3": {
            "url": "be4dbdbe267c83abfd2072170f671020_cellLandscape_x3.jpg"
        },
        "cellLandscape_x2": {
            "url": "be4dbdbe267c83abfd2072170f671020_cellLandscape_x2.jpg"
        }
    }
]
`