### PR TITLE
Reset properties to allow an instance of the ProcessService to be reused

### DIFF
--- a/feedme/services/FeedMe_ProcessService.php
+++ b/feedme/services/FeedMe_ProcessService.php
@@ -41,6 +41,10 @@ class FeedMe_ProcessService extends BaseApplicationComponent
 
         craft()->config->maxPowerCaptain();
 
+        // Reset properties to allow an instance of this service to be reused
+        $this->_processedElements = array();
+        $this->_processedElementIds = array();
+
         // Add some additional information to our FeedModel - for ease of use in processing
         $return['fields'] = array();
         $return['existingElements'] = array();


### PR DESCRIPTION
If multiple FeedMeTask tasks are queued up at the same time, it looks like the same FeedMe_ProcessService gets reused. The problem is that the service isn't particularly re-entrant. Specifically, the properties `_processedElements` and `_processedElementIds` never get reset. It leads to behavior like this:

```
2017/08/22 04:02:14 [info] [plugin] [Forced] Products: Processing 500 elements finished in 169.70s
2017/08/22 04:05:00 [info] [plugin] [Forced] Products: Processing 1000 elements finished in 165.85s
2017/08/22 04:07:57 [info] [plugin] [Forced] Products: Processing 1500 elements finished in 177.21s
2017/08/22 04:11:18 [info] [plugin] [Forced] Products: Processing 2000 elements finished in 200.95s
2017/08/22 04:14:18 [info] [plugin] [Forced] Products: Processing 2500 elements finished in 178.85s
2017/08/22 04:17:56 [info] [plugin] [Forced] Products: Processing 3000 elements finished in 218.34s
2017/08/22 04:21:41 [info] [plugin] [Forced] Products: Processing 3500 elements finished in 224.93s
2017/08/22 04:25:36 [info] [plugin] [Forced] Products: Processing 4000 elements finished in 234.98s
2017/08/22 04:28:43 [info] [plugin] [Forced] Products: Processing 4500 elements finished in 186.80s
2017/08/22 04:33:05 [info] [plugin] [Forced] Products: Processing 4999 elements finished in 261.19s
```

Both the number of elements processed keeps increasing and the amount of time it takes to process them trends upwards. The upwards trend is more significant on this run, in which I increased the number of files being imported:

```
2017/08/22 03:50:06 [info] [plugin] [Forced] Products: Processing 500 elements finished in 161.63s
2017/08/22 03:52:56 [info] [plugin] [Forced] Products: Processing 500 elements finished in 167.25s
2017/08/22 02:48:17 [info] [plugin] [Forced] Products: Processing 500 elements finished in 169.75s
2017/08/22 02:51:11 [info] [plugin] [Forced] Products: Processing 1000 elements finished in 174.24s
2017/08/22 02:54:00 [info] [plugin] [Forced] Products: Processing 1500 elements finished in 168.27s
2017/08/22 02:57:12 [info] [plugin] [Forced] Products: Processing 2000 elements finished in 191.84s
2017/08/22 03:00:18 [info] [plugin] [Forced] Products: Processing 2500 elements finished in 185.35s
2017/08/22 03:05:08 [info] [plugin] [Forced] Products: Processing 3000 elements finished in 290.34s
2017/08/22 03:09:59 [info] [plugin] [Forced] Products: Processing 3500 elements finished in 291.28s
2017/08/22 03:15:04 [info] [plugin] [Forced] Products: Processing 4000 elements finished in 304.41s
2017/08/22 03:20:09 [info] [plugin] [Forced] Products: Processing 4500 elements finished in 304.96s
2017/08/22 03:25:27 [info] [plugin] [Forced] Products: Processing 4999 elements finished in 317.67s
2017/08/22 03:31:38 [info] [plugin] [Forced] Products: Processing 5497 elements finished in 370.43s
2017/08/22 03:36:49 [info] [plugin] [Forced] Products: Processing 5966 elements finished in 310.92s
2017/08/22 03:42:18 [info] [plugin] [Forced] Products: Processing 6466 elements finished in 328.89s
```

The last run takes over twice as long as the first run.

After the modification make in the PR, I get this output when processing the same 10 files as above:

```
2017/08/22 05:33:39 [info] [plugin] [Forced] Products: Processing 500 elements finished in 185.70s
2017/08/22 05:36:34 [info] [plugin] [Forced] Products: Processing 500 elements finished in 174.68s
2017/08/22 05:39:37 [info] [plugin] [Forced] Products: Processing 500 elements finished in 183.26s
2017/08/22 05:42:55 [info] [plugin] [Forced] Products: Processing 500 elements finished in 198.13s
2017/08/22 05:46:04 [info] [plugin] [Forced] Products: Processing 500 elements finished in 188.06s
2017/08/22 05:49:37 [info] [plugin] [Forced] Products: Processing 500 elements finished in 213.14s
2017/08/22 05:53:25 [info] [plugin] [Forced] Products: Processing 500 elements finished in 227.48s
2017/08/22 05:56:30 [info] [plugin] [Forced] Products: Processing 499 elements finished in 185.57s
2017/08/22 06:00:04 [info] [plugin] [Forced] Products: Processing 500 elements finished in 213.24s
2017/08/22 06:03:51 [info] [plugin] [Forced] Products: Processing 499 elements finished in 226.91s
```

The number of elements being processed holds steady at 500, which is how many are in each file. It looks like the processing time remains a bit more consistent as well. I'm working on a more thorough test.