### PR TITLE
Fix parseParent when more than one entry matches

### DIFF
--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -148,6 +148,7 @@ class Entry extends Element implements ElementInterface
 
         $query = EntryElement::find()
             ->status(null)
+            ->sectionId($this->element->sectionId)
             ->andWhere(['=', $match, $value]);
 
         if (isset($this->feed['siteId']) && $this->feed['siteId']) {


### PR DESCRIPTION
If more than one entry matches the query for parent, and the first returned happens to be in a different section element fails to be imported.