### PR TITLE
Commerce fields - Fix not matching elements when limiting to a source

### DIFF
--- a/src/fields/CommerceProducts.php
+++ b/src/fields/CommerceProducts.php
@@ -8,6 +8,7 @@ use craft\commerce\elements\Product as ProductElement;
 use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
 use craft\feedme\Plugin;
+use craft\helpers\Db;
 
 class CommerceProducts extends Field implements FieldInterface
 {
@@ -48,7 +49,7 @@ class CommerceProducts extends Field implements FieldInterface
         if (is_array($sources)) {
             foreach ($sources as $source) {
                 list($type, $uid) = explode(':', $source);
-                $typeIds[] = $uid;
+                $typeIds[] = Db::idByUid('{{%commerce_producttypes}}', $uid);
             }
         } else if ($sources === '*') {
             $typeIds = null;

--- a/src/fields/CommerceVariants.php
+++ b/src/fields/CommerceVariants.php
@@ -8,6 +8,7 @@ use craft\commerce\elements\Variant as VariantElement;
 use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
 use craft\feedme\Plugin;
+use craft\helpers\Db;
 
 class CommerceVariants extends Field implements FieldInterface
 {
@@ -48,7 +49,7 @@ class CommerceVariants extends Field implements FieldInterface
         if (is_array($sources)) {
             foreach ($sources as $source) {
                 list($type, $uid) = explode(':', $source);
-                $typeIds[] = $uid;
+                $typeIds[] = Db::idByUid('{{%commerce_producttypes}}', $uid);
             }
         } else if ($sources === '*') {
             $typeIds = null;

--- a/src/fields/DefaultField.php
+++ b/src/fields/DefaultField.php
@@ -44,9 +44,13 @@ class DefaultField extends Field implements FieldInterface
         if ($value !== '') {
             $value = $this->field->normalizeValue($value);
         }
-
+        
         // Lastly, get each field to prepare values how they should
-        $value = $this->field->serializeValue($value);
+        try {
+            $value = $this->field->serializeValue($value);
+        } catch (\Throwable $e) {
+            // Ignore
+        }
 
         return $value;
     }

--- a/src/fields/DigitalProducts.php
+++ b/src/fields/DigitalProducts.php
@@ -8,6 +8,7 @@ use craft\digitalproducts\elements\Product as ProductElement;
 use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
 use craft\feedme\Plugin;
+use craft\helpers\Db;
 
 class DigitalProducts extends Field implements FieldInterface
 {
@@ -48,7 +49,7 @@ class DigitalProducts extends Field implements FieldInterface
         if (is_array($sources)) {
             foreach ($sources as $source) {
                 list($type, $uid) = explode(':', $source);
-                $typeIds[] = $uid;
+                $typeIds[] = Db::idByUid('{{%digitalproducts_producttypes}}', $uid);
             }
         } else if ($sources === '*') {
             $typeIds = null;


### PR DESCRIPTION
If the field is set to a specific product type, it won't match elements. This fixes that.