### PR TITLE
Add support for VZAddress field type

### DIFF
--- a/src/fields/VzAddress.php
+++ b/src/fields/VzAddress.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace craft\feedme\fields;
+
+use Cake\Utility\Hash;
+use craft\feedme\base\Field;
+use craft\feedme\base\FieldInterface;
+use craft\feedme\helpers\DataHelper;
+
+class VZAddress extends Field implements FieldInterface
+{
+    // Properties
+    // =========================================================================
+
+    public static $name = 'VZAddress';
+    public static $class = 'superbig\vzaddress\fields\VzAddressField';
+
+
+    // Templates
+    // =========================================================================
+
+    public function getMappingTemplate()
+    {
+        return 'feed-me/_includes/fields/vzaddress';
+    }
+
+
+    // Public Methods
+    // =========================================================================
+
+    public function parseField()
+    {
+        $preppedData = [];
+
+        $fields = Hash::get($this->fieldInfo, 'fields');
+
+        if (!$fields) {
+            return null;
+        }
+
+        foreach ($fields as $subFieldHandle => $subFieldInfo) {
+            $preppedData[$subFieldHandle] = DataHelper::fetchValue($this->feedData, $subFieldInfo);
+        }
+
+        // Protect against sending an empty array
+        if (!$preppedData) {
+            return null;
+        }
+
+        return $preppedData;
+    }
+
+}

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -32,6 +32,7 @@ use craft\feedme\fields\Table;
 use craft\feedme\fields\Tags;
 use craft\feedme\fields\TypedLink;
 use craft\feedme\fields\Users;
+use craft\feedme\fields\VZAddress;
 use craft\helpers\Component as ComponentHelper;
 
 class Fields extends Component
@@ -124,6 +125,7 @@ class Fields extends Component
                 SmartMap::class,
                 SuperTable::class,
                 TypedLink::class,
+                VZAddress::class
             ],
         ]);
 

--- a/src/templates/_includes/fields/vzaddress.html
+++ b/src/templates/_includes/fields/vzaddress.html
@@ -1,0 +1,68 @@
+{# ------------------------ #}
+{# Available Variables #}
+{# ------------------------ #}
+{# Attributes: #}
+{# type, name, handle, instructions, attribute, default, feed, feedData #}
+{# ------------------------ #}
+{# Fields: #}
+{# name, handle, instructions, feed, feedData, field, fieldClass #}
+{# ------------------------ #}
+
+{% import 'feed-me/_macros' as feedMeMacro %}
+{% import '_includes/forms' as forms %}
+
+{# Special case when inside another complex field (Matrix) #}
+{% if parentPath is defined %}
+    {% set prefixPath = parentPath %}
+{% else %}
+    {% set prefixPath = [handle] %}
+{% endif %}
+
+{% set classes = ['complex-field'] %}
+
+<tr class="complex-field complex-field-header">
+    <td class="col-field" colspan="3">
+        <div class="field">
+            <div class="heading">
+                <label class="">{{ name }}</label>
+            </div>
+
+            <div class="additional-mapping-fields">
+                {% namespace 'fieldMapping[' ~ prefixPath | join('][') ~ ']' %}
+                    <input type="text" name="field" value="{{ className(field) }}">
+                {% endnamespace %}
+            </div>
+        </div>
+    </td>
+</tr>
+
+{% set vzAddressSubfields = {
+    name: 'Name',
+    street: 'Street Address',
+    street2: 'Street Address 2',
+    city: 'City',
+    region: 'State/Province',
+    postalCode: 'Postal Code',
+    country: 'Country'
+} %}
+
+{% for key, col in vzAddressSubfields %}
+    {% set nameLabel = col %}
+    {% set instructionsHandle = handle ~ '[' ~ key ~ ']' %}
+
+    {% set path = prefixPath | merge ([ 'fields', key ]) %}
+
+    {% set default = default ?? {
+        type: 'text',
+    } %}
+
+    {% embed 'feed-me/_includes/fields/_base' %}
+        {% block additionalFieldSettings %}
+
+        {% endblock %}
+
+        {% block fieldSettings %}
+
+        {% endblock %}
+    {% endembed %}
+{% endfor %}


### PR DESCRIPTION
Hi,

We're using the VZAddress field type (https://github.com/superbigco/craft-vzaddress) and whilst this was supported in Feed Me for Craft 2 (via https://github.com/verbb/feed-me-helpers), it's no longer included in Craft 3.

This is a relatively simple field type and we use it a lot so would be great to get it supported in the Plugin 