### PR TITLE
Sort arrays when comparing elements so that same values in different order doesn't trigger update

### DIFF
--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -174,6 +174,12 @@ class DataHelper
                 $newValue = null;
             }
 
+            // If arrays of values, sort them to help comparison
+            if (is_array($existingValue) && is_array($newValue)) {
+                sort($existingValue);
+                sort($newValue);
+            }
+
             // Check for simple fields first
             if ($existingValue == $newValue) {
                 unset($trackedChanges[$key]);


### PR DESCRIPTION
Fields like e.g. Category fields will trigger an update and resave of the element if arrays are identical, but values come in different order. Sorting them should fix this.