### PR TITLE
Trigger event from object, not static method

### DIFF
--- a/src/services/DataTypes.php
+++ b/src/services/DataTypes.php
@@ -190,7 +190,7 @@ class DataTypes extends Component
             'response' => $feedDataResponse,
         ]);
 
-        Event::trigger(static::class, self::EVENT_AFTER_PARSE_FEED, $event);
+        $this->trigger(self::EVENT_AFTER_PARSE_FEED, $event);
 
         return $event->response;
     }


### PR DESCRIPTION
When using behaviors to handle events, event won't fire when it is called with the static method, as the behavior is added dynamically, but when using `this->trigger()` it will, so I suggest to trigger it from the object itself. (If there's no specific reason to do it otherwise, perhaps all event triggers could be changed in the same way.)

Fixes #730 