### PR TITLE
Adding processElementIds to event

### DIFF
--- a/src/events/FeedProcessEvent.php
+++ b/src/events/FeedProcessEvent.php
@@ -13,4 +13,5 @@ class FeedProcessEvent extends CancelableEvent
     public $feedData;
     public $contentData;
     public $element;
+    public $processedElementIds;
 }

--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -486,6 +486,19 @@ class Process extends Component
             return;
         }
 
+
+        // Fire an 'onProcessFeed' event
+        $event = new FeedProcessEvent([
+            'feed' => $feed,
+            'processedElementIds' => $processedElementIds,
+        ]);
+
+        $this->trigger(self::EVENT_AFTER_PROCESS_FEED, $event);
+
+        // Allow event to modify variables
+        $feed = $event->feed;
+        $processedElementIds = $event->processedElementIds;
+
         $elementsToDeleteDisable = array_diff($settings['existingElements'], $processedElementIds);
 
         if ($elementsToDeleteDisable) {
@@ -513,13 +526,6 @@ class Process extends Component
         $message = 'Processing ' . count($processedElementIds) . ' elements finished in ' . $execution_time . 's';
         Plugin::info($message);
         Plugin::debug($message);
-
-        // Fire an 'onProcessFeed' event
-        $event = new FeedProcessEvent([
-            'feed' => $feed,
-        ]);
-
-        $this->trigger(self::EVENT_AFTER_PROCESS_FEED, $event);
     }
 
     /**


### PR DESCRIPTION
Letting the afterProcessFeed event modify the processed element IDs, so existing elements can be shielded from being deleted/disabled.  #744