### PR TITLE
check for usedefault before returning folder as a default folder

### DIFF
--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -255,13 +255,14 @@ class Asset extends Element
     {
         $value = $this->fetchSimpleValue($feedData, $fieldInfo);
         $create = Hash::get($fieldInfo, 'options.create');
-
+        $node = Hash::get($fieldInfo, 'node');
+        
         $assets = Craft::$app->getAssets();
 
         $volumeId = $this->element->volumeId;
         $rootFolder = $assets->getRootFolderByVolumeId($volumeId);
 
-        if (is_numeric($value)) {
+        if ($node == 'usedefault' && is_numeric($value)) {
             return $value;
         }
 


### PR DESCRIPTION
**Description**
currently if folder is numeric, feed-me assumes that folder is a default folder . this PR checks if node value is usedefault.

**Related issues**
[https://github.com/craftcms/feed-me/issues/581](https://github.com/craftcms/feed-me/issues/581)
