### PR TITLE
check for parentId in findfolder()

### DIFF
--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -276,16 +276,19 @@ class Asset extends Element
 
         if ($create) {
             $lastCreatedFolder = null;
+            $parentId = $rootFolder->id;
 
             // Process all folders (create them)
             foreach (explode('/', $value) as $key => $folderName) {
                 $existingFolder = $assets->findFolder([
                     'name' => $folderName,
                     'volumeId' => $volumeId,
+                    'parentId' => $parentId,
                 ]);
 
                 if ($existingFolder) {
                     $lastCreatedFolder = $existingFolder;
+                    $parentId = $existingFolder->id;
                     continue;
                 }
 
@@ -300,6 +303,7 @@ class Asset extends Element
                 $assets->createFolder($folderModel);
 
                 $lastCreatedFolder = $folderModel;
+                $parentId = $folderModel->id;
             }
 
             // Then, we just want the lowest level folder to use


### PR DESCRIPTION
**Description**
 if a subfolder has same name as parent folder, findfolder() always returns parent folder and asset moves to parent folder instead of sub folder. this PR keeps track of parentId and add parentId to findfolder() condition.




