### PR TITLE
Ability to paginate with feeds that provide a page number instead of the next page URL. 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "craftcms/feed-me",
     "description": "Import content from XML, RSS, CSV or JSON feeds into entries, categories, Craft Commerce products, and more.",
     "type": "craft-plugin",
-    "version": "4.3.6",
+    "version": "4.3.7",
     "keywords": [
         "craft",
         "cms",

--- a/src/controllers/FeedsController.php
+++ b/src/controllers/FeedsController.php
@@ -400,6 +400,7 @@ class FeedsController extends Controller
         $feed->singleton = $request->getBodyParam('singleton', $feed->singleton);
         $feed->duplicateHandle = $request->getBodyParam('duplicateHandle', $feed->duplicateHandle);
         $feed->paginationNode = $request->getBodyParam('paginationNode', $feed->paginationNode);
+        $feed->paginationTotalNode = $request->getBodyParam('paginationTotalNode', $feed->paginationTotalNode);
         $feed->passkey = $request->getBodyParam('passkey', $feed->passkey);
         $feed->backup = (bool)$request->getBodyParam('backup', $feed->backup);
 

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -41,6 +41,7 @@ class Install extends Migration
             'singleton' => $this->boolean()->notNull()->defaultValue(false),
             'duplicateHandle' => $this->text(),
             'paginationNode' => $this->text(),
+            'paginationTotalNode' => $this->text(),
             'fieldMapping' => $this->text(),
             'fieldUnique' => $this->text(),
             'passkey' => $this->string()->notNull(),

--- a/src/migrations/m210313_164741_migration_for_total_page_number.php
+++ b/src/migrations/m210313_164741_migration_for_total_page_number.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace craft\feedme\migrations;
+
+use Craft;
+use craft\db\Migration;
+
+/**
+ * m210313_164741_migration_for_total_page_number migration.
+ */
+class m210313_164741_migration_for_total_page_number extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        if (!$this->db->columnExists('{{%feedme_feeds}}', 'paginationTotalNode')) {
+            $this->addColumn('{{%feedme_feeds}}', 'paginationTotalNode', $this->text()->after('duplicateHandle'));
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        echo "m210313_164741_migration_for_total_page_number cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/models/FeedModel.php
+++ b/src/models/FeedModel.php
@@ -86,6 +86,11 @@ class FeedModel extends Model
     /**
      * @var
      */
+    public $paginationTotalNode;
+
+    /**
+     * @var
+     */
     public $fieldMapping;
 
     /**
@@ -219,11 +224,6 @@ class FeedModel extends Model
      */
     public function getNextPagination()
     {
-        //check if the pagination url provided is just a page number
-        if ($this->_generateNextPaginationFromPageNumber()) {
-            return true;
-        }
-
         if (!$this->paginationUrl || !filter_var($this->paginationUrl, FILTER_VALIDATE_URL)) {
             return false;
         }
@@ -243,50 +243,6 @@ class FeedModel extends Model
             [['name', 'feedUrl', 'feedType', 'elementType', 'duplicateHandle', 'passkey'], 'required'],
             [['backup'], 'boolean'],
         ];
-    }
-
-    private function _generateNextPaginationFromPageNumber() {
-        if (is_numeric($this->paginationUrl)) {
-            $nextPage = $this->paginationUrl + 1;
-            if($nextPage > 13) {
-                return false;
-            }
-
-            $this->feedUrl = $this->_setPageQueryString($this->feedUrl, "page", $nextPage);
-            return true;
-        }
-    }
-
-    private function _setPageQueryString($url, $param, $value)
-    {
-        //remove query string if it already exists
-        $pieces = parse_url($url);
-        if (!isset($pieces['query']) || !$pieces['query']) {
-            return $this->_addQueryString($url, $param, $value);
-        }
-
-        $query = [];
-        parse_str($pieces['query'], $query);
-        if (!isset($query[$param])) {
-            return $this->_addQueryString($url, $param, $value);
-        }
-
-        unset($query[$param]);
-        $pieces['query'] = http_build_query($query);
-
-        $url = http_build_url($pieces);
-        return $this->_addQueryString($url, $param, $value);
-    }
-
-    private function _addQueryString($url, $param, $value)
-    {
-        $url = preg_replace('/(.*)(?|&)'. $param .'=[^&]+?(&)(.*)/i', '$1$2$4', $url .'&');
-        $url = substr($url, 0, -1);
-        if (strpos($url, '?') === false) {
-            return ($url .'?'. $param .'='. $value);
-        } else {
-            return ($url .'&'. $param .'='. $value);
-        }
     }
 
 }

--- a/src/services/Feeds.php
+++ b/src/services/Feeds.php
@@ -123,6 +123,7 @@ class Feeds extends Component
         $record->singleton = (bool)$model->singleton;
         $record->duplicateHandle = $model->duplicateHandle;
         $record->paginationNode = $model->paginationNode;
+        $record->paginationTotalNode = $model->paginationTotalNode;
         $record->passkey = $model->passkey;
         $record->backup = $model->backup;
 
@@ -252,6 +253,7 @@ class Feeds extends Component
                 'singleton',
                 'duplicateHandle',
                 'paginationNode',
+                'paginationTotalNode',
                 'fieldMapping',
                 'fieldUnique',
                 'passkey',

--- a/src/templates/feeds/_element.html
+++ b/src/templates/feeds/_element.html
@@ -60,13 +60,23 @@
         {% endfor %}
 
         {{ forms.selectField({
-            label: "Pagination URL"|t('feed-me'),
-            instructions: 'If your feed is paginated, select the next page’s URL.'|t('feed-me'),
+            label: "Pagination URL or Page Number"|t('feed-me'),
+            instructions: 'If your feed is paginated, select the next page’s URL, or the current page number.'|t('feed-me'),
             id: 'paginationNode',
             name: 'paginationNode',
             value: feed.paginationNode,
             options: parsedFeedData,
             errors: feed.getErrors('paginationNode'),
+        }) }}
+
+        {{ forms.selectField({
+            label: "Pagination Total Pages"|t('feed-me'),
+            instructions: 'If your feed is paginated using page numbers, select the field containing the total pages. This is required if your feed uses page numbers.'|t('feed-me'),
+            id: 'paginationTotalNode',
+            name: 'paginationTotalNode',
+            value: feed.paginationTotalNode,
+            options: parsedFeedData,
+            errors: feed.getErrors('paginationTotalNode'),
         }) }}
 
     {% else %}


### PR DESCRIPTION
## Description

This PR adds the ability to check the next page URL for the case where a page number is provided instead of the next page's URL. Some feeds only provide the current page information instead of the URL to the next page. Example of such feed below:

```
{
    "data":[
      ...
    ],
    "paging": {
        "page": 1,
        "perPage": 200,
        "pageCount": 13
    }
}
```

In this case, we are checking if the data provided as the next page is numeric, and a total page number is provided as well. In this case, we generate a URL using the `feedUrl` and appending the query string `?page={number}` by incrementing the current page number. This is then repeated until the total page count provided is reached.

### What is included:
- The addition of the new field to provide the total pages
- Edited the description in the settings form to explain that a page number can be provided instead of a URL
- Added a database migration file to add the total page number
- Incremented the plugin version number for migration (not sure if this is allowed)
- Added the functionality mentioned above the to the `setupPaginationUrl($array, $feed)` function in the `DataType` class, making use of the `UrlHelper` function to add the query string

### What is not included
- I was not able to run the unit tests as I was getting errors while running, therefore I was not able to confirm if tests are ok, or even add any if needed. Help on this would be appreciated
- I also was not able to test on feeds that provide a normal next page URL. 

In general, help in testing would be appreciated.

## Related Issues
I apologise for not creating an issue before, but I needed this feature anyway for a project I'm working on. 