### PR TITLE
fix: force cakephp/utility < 3.9.5 to fix PHP 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require": {
         "craftcms/cms": "^3.7.0",
-        "cakephp/utility": "^3.3.12",
+        "cakephp/utility": "^3.3.12,<3.9.5",
         "jakeasmith/http_build_url": "^1.0",
         "nesbot/carbon": "^1.22 || ^2.10",
         "league/csv": "^8.2 || ^9.0",


### PR DESCRIPTION
cakephp/utility 3.9.5 introduces a dependency to PHP < 8.0.0.

This prevents installing/updating feed-me when using PHP 8, and also breaks the
`craft update all` command, even when there are no feed-me updates.