### PR TITLE
Disable validation on existing Commerce Product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed several bugs related to empty and non-existent feed values and the “Set Empty Values” feed setting. ([#1271](https://github.com/craftcms/feed-me/pull/1271))
 - Fixed a bug where that prevented importing data as Commerce Variants. ([#464](https://github.com/craftcms/feed-me/issues/464), [#1168](https://github.com/craftcms/feed-me/issues/1168))
 - Fixed an XSS vulnerability.
+- Fixed a bug where updating an existing Commerce Product triggers validation. ([#1034](https://github.com/craftcms/feed-me/issues/1034))
 
 ## 4.6.1.1 - 2023-03-24 
 

--- a/src/elements/CommerceProduct.php
+++ b/src/elements/CommerceProduct.php
@@ -147,7 +147,13 @@ class CommerceProduct extends Element
     {
         $this->beforeSave($element, $settings);
 
-        if (!Craft::$app->getElements()->saveElement($this->element, true, true, Hash::get($this->feed, 'updateSearchIndexes'))) {
+        $runValidation = true;
+
+        if ($element->id !== null) {
+            $runValidation = false;
+        }
+
+        if (!Craft::$app->getElements()->saveElement($this->element, $runValidation, true, Hash::get($this->feed, 'updateSearchIndexes'))) {
             $errors = [$this->element->getErrors()];
 
             if ($this->element->getErrors()) {


### PR DESCRIPTION


### Description

Fixed a bug where updating an existing Commerce Product triggers validation. [#1034]
