### PR TITLE
Rename mapping from parent to parentId

### DIFF
--- a/src/elements/Category.php
+++ b/src/elements/Category.php
@@ -132,7 +132,7 @@ class Category extends Element
      * @throws ElementNotFoundException
      * @throws Exception
      */
-    protected function parseParent($feedData, $fieldInfo): ?int
+    protected function parseParentId($feedData, $fieldInfo): ?int
     {
         $value = $this->fetchSimpleValue($feedData, $fieldInfo);
         $default = DataHelper::fetchDefaultArrayValue($fieldInfo);

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -224,7 +224,7 @@ class Entry extends Element
      * @throws ElementNotFoundException
      * @throws Exception
      */
-    protected function parseParent($feedData, $fieldInfo): ?int
+    protected function parseParentId($feedData, $fieldInfo): ?int
     {
         $value = $this->fetchSimpleValue($feedData, $fieldInfo);
         $default = DataHelper::fetchDefaultArrayValue($fieldInfo);

--- a/src/migrations/m231025_081246_rename_parent_to_parentid_for_feedme_imports.php
+++ b/src/migrations/m231025_081246_rename_parent_to_parentid_for_feedme_imports.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace craft\feedme\migrations;
+
+use craft\db\Migration;
+use craft\db\Query;
+
+/**
+ * m231025_081246_rename_parent_to_parentid_for_feedme_imports migration.
+ */
+class m231025_081246_rename_parent_to_parentid_for_feedme_imports extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        $rows = (new Query())
+            ->select(['id', 'fieldMapping'])
+            ->from('{{%feedme_feeds}}')
+            ->all();
+
+        foreach ($rows as $row) {
+            $fieldMapping = \json_decode($row['fieldMapping']);
+
+            // Rename the `parent` argument into `parentId` if it exists
+            if (isset($fieldMapping->parent)) {
+                $fieldMapping->parentId = $fieldMapping->parent;
+                unset($fieldMapping->parent);
+
+                $this->update(
+                    '{{%feedme_feeds}}',
+                    ['fieldMapping' => \json_encode($fieldMapping)],
+                    ['id' => $row['id']]
+                );
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        $rows = (new Query())
+            ->select(['id', 'fieldMapping'])
+            ->from('{{%feedme_feeds}}')
+            ->all();
+
+        foreach ($rows as $row) {
+            $fieldMapping = \json_decode($row['fieldMapping']);
+
+            // Rename the `parentId` argument back into `parent` if it exists
+            if (isset($fieldMapping->parentId)) {
+                $fieldMapping->parent = $fieldMapping->parentId;
+                unset($fieldMapping->parentId);
+
+                $this->update(
+                    '{{%feedme_feeds}}',
+                    ['fieldMapping' => \json_encode($fieldMapping)],
+                    ['id' => $row['id']]
+                );
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/templates/_includes/elements/categories/map.html
+++ b/src/templates/_includes/elements/categories/map.html
@@ -23,7 +23,7 @@
 }, {
     type: 'categories',
     name: 'Parent',
-    handle: 'parent',
+    handle: 'parentId',
     instructions: 'Select a parent category to import these categories under.'|t('feed-me'),
     default: {
         type: 'elementselect',

--- a/src/templates/_includes/elements/entries/map.html
+++ b/src/templates/_includes/elements/entries/map.html
@@ -30,7 +30,7 @@
     {% set fields = fields|push({
         type: 'entries',
         name: 'Parent',
-        handle: 'parent',
+        handle: 'parentId',
         instructions: 'Select a parent entry to import these entries under.'|t('feed-me'),
         default: {
             type: 'elementselect',


### PR DESCRIPTION
The attribute `parentId` is used in Craft to signify the value of the parent element, if any.  Therefore, the mapping handle should also be `parentId`.

This patch changes the mapping handle from `parent` into `parentId`. This allows the comparison code to properly verify that an existing parent already exists.  Without this patch the current comparison will use the `parent` property that does not exist in a Craft entry.  This should have been `parentId` which does exist.

A migration is included to rename `parent` to `parentId` in any existing migrations that may already exist.
