### PR TITLE
Bugfix/1340 update feeds after entrification

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -5,7 +5,9 @@ namespace craft\feedme;
 use Craft;
 use craft\base\Model;
 use craft\console\controllers\EntrifyController;
-use craft\events\EntrifyEvent;
+use craft\events\EntrifyCategoriesEvent;
+use craft\events\EntrifyGlobalSetEvent;
+use craft\events\EntrifyTagsEvent;
 use craft\events\RegisterUrlRulesEvent;
 use craft\feedme\base\PluginTrait;
 use craft\feedme\models\Settings;
@@ -182,9 +184,25 @@ class Plugin extends \craft\base\Plugin
     {
         Event::on(
             EntrifyController::class,
-            EntrifyController::EVENT_AFTER_ENTRIFY,
-            function(EntrifyEvent $event) {
-                self::$plugin->feeds->entrifyFeeds($event->elementType, $event->elementGroup);
+            EntrifyController::EVENT_ENTRIFY_CATEGORIES,
+            function(EntrifyCategoriesEvent $event) {
+                self::$plugin->feeds->entrifyCategoryFeeds($event);
+            }
+        );
+
+        Event::on(
+            EntrifyController::class,
+            EntrifyController::EVENT_ENTRIFY_TAGS,
+            function(EntrifyTagsEvent $event) {
+                self::$plugin->feeds->entrifyTagFeeds($event);
+            }
+        );
+
+        Event::on(
+            EntrifyController::class,
+            EntrifyController::EVENT_ENTRIFY_GLOBAL_SET,
+            function(EntrifyGlobalSetEvent $event) {
+                self::$plugin->feeds->entrifyGlobalSetFeeds($event);
             }
         );
     }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -4,6 +4,8 @@ namespace craft\feedme;
 
 use Craft;
 use craft\base\Model;
+use craft\console\controllers\EntrifyController;
+use craft\events\EntrifyEvent;
 use craft\events\RegisterUrlRulesEvent;
 use craft\feedme\base\PluginTrait;
 use craft\feedme\models\Settings;
@@ -86,6 +88,7 @@ class Plugin extends \craft\base\Plugin
         $this->_registerCpRoutes();
         $this->_registerTwigExtensions();
         $this->_registerVariables();
+        $this->_listenToEvents();
     }
 
     /**
@@ -168,5 +171,21 @@ class Plugin extends \craft\base\Plugin
         Event::on(CraftVariable::class, CraftVariable::EVENT_INIT, function(Event $event) {
             $event->sender->set('feedme', FeedMeVariable::class);
         });
+    }
+
+    /**
+     * Listen to events
+     *
+     * @return void
+     */
+    private function _listenToEvents(): void
+    {
+        Event::on(
+            EntrifyController::class,
+            EntrifyController::EVENT_AFTER_ENTRIFY,
+            function (EntrifyEvent $event) {
+                self::$plugin->feeds->entrifyFeeds($event->elementType, $event->elementGroup);
+            }
+        );
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -183,7 +183,7 @@ class Plugin extends \craft\base\Plugin
         Event::on(
             EntrifyController::class,
             EntrifyController::EVENT_AFTER_ENTRIFY,
-            function (EntrifyEvent $event) {
+            function(EntrifyEvent $event) {
                 self::$plugin->feeds->entrifyFeeds($event->elementType, $event->elementGroup);
             }
         );

--- a/src/services/Feeds.php
+++ b/src/services/Feeds.php
@@ -250,6 +250,14 @@ class Feeds extends Component
     {
         $allFeeds = $this->getFeeds();
 
+        $sectionsService = Craft::$app->getSections();
+        $section = $sectionsService->getSectionByUid($elementGroup['to']['section']);
+        $entryType = $sectionsService->getEntryTypeByUid($elementGroup['to']['entryType']);
+
+        if (!$section || !$entryType) {
+            return;
+        }
+
         foreach ($allFeeds as $feed) {
             if ($feed->elementType === $elementType) {
                 // if, in the elementGroup, the key matches $elementType
@@ -257,8 +265,8 @@ class Feeds extends Component
                 // (in case of GlobalSet, the value would be ['globalSet' => <globalSetId>])
                 if (isset($feed->elementGroup[$elementType]) &&
                     (
-                        $feed->elementGroup[$elementType] == $elementGroup['from'] ||
-                        ($elementType === GlobalSet::class && $feed->elementGroup[$elementType] == ['globalSet' => $elementGroup['from']])
+                        $feed->elementGroup[$elementType] == $elementGroup['from']['id'] ||
+                        ($elementType === GlobalSet::class && $feed->elementGroup[$elementType] == ['globalSet' => $elementGroup['from']['id']])
                     )
                 ) {
                     // change the elementType
@@ -267,8 +275,8 @@ class Feeds extends Component
                     $feed->elementGroup[$elementType] = "";
                     // in the elementGroup change the value for the craft\elements\Entry key
                     $feed->elementGroup[Entry::class] = [
-                        'section' => $elementGroup['to']['sectionId'],
-                        'entryType' => $elementGroup['to']['typeId'],
+                        'section' => $section->id,
+                        'entryType' => $entryType->id,
                     ];
 
                     $this->saveFeed($feed);


### PR DESCRIPTION
### Description
Take advantage of `EntrifyEvent` added via https://github.com/craftcms/cms/pull/13391.

After entrification, Feed Me utilises this event to adjust the feeds that were importint into the entrified Category/Tag/Global Set element.

It changes the feed’s `elementType` to Entry and `elementGroup` from the Category/Tag/Global Set element to the Entry section and type ids.


### Related issues
#1340 
