### PR TITLE
Implement naive feed configuration storage

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -7,6 +7,7 @@ use craft\base\Model;
 use craft\events\RegisterUrlRulesEvent;
 use craft\feedme\base\PluginTrait;
 use craft\feedme\models\Settings;
+use craft\feedme\services\FeedConfigStorage;
 use craft\feedme\services\DataTypes;
 use craft\feedme\services\Elements;
 use craft\feedme\services\Feeds;
@@ -26,6 +27,7 @@ use yii\queue\Queue;
 /**
  * Class Plugin
  *
+ * @property-read FeedConfigStorage $config
  * @property-read DataTypes $data
  * @property-read Elements $elements
  * @property-read Feeds $feeds
@@ -50,6 +52,7 @@ class Plugin extends \craft\base\Plugin
     {
         return [
             'components' => [
+                'config' => ['class' => FeedConfigStorage::class],
                 'data' => ['class' => DataTypes::class],
                 'elements' => ['class' => Elements::class],
                 'feeds' => ['class' => Feeds::class],

--- a/src/base/PluginTrait.php
+++ b/src/base/PluginTrait.php
@@ -4,6 +4,7 @@ namespace craft\feedme\base;
 
 use Craft;
 use craft\feedme\Plugin;
+use craft\feedme\services\FeedConfigStorage;
 use craft\feedme\services\DataTypes;
 use craft\feedme\services\Elements;
 use craft\feedme\services\Feeds;
@@ -77,6 +78,15 @@ trait PluginTrait
 
     // Public Methods
     // =========================================================================
+
+    /**
+     * @return FeedConfigStorage
+     * @throws \yii\base\InvalidConfigException
+     */
+    public function getFeedConfigStorage(): FeedConfigStorage
+    {
+        return $this->get('feedConfigStorage');
+    }
 
     /**
      * @return DataTypes

--- a/src/console/controllers/FeedConfigStorageController.php
+++ b/src/console/controllers/FeedConfigStorageController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace craft\feedme\console\controllers;
+
+use craft\feedme\Plugin;
+use craft\helpers\Console;
+use yii\console\Controller;
+use yii\console\ExitCode;
+
+/**
+ * Read from or write to configuration file
+ *
+ * @property Plugin $module
+ */
+class FeedConfigStorageController extends Controller
+{
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * @inheritDoc
+     */
+    public function options($actionID): array
+    {
+        $options = parent::options($actionID);
+        return $options;
+    }
+
+    /**
+     * Writes feeds records to file
+     *
+     * @return int
+     */
+    public function actionWrite(): int
+    {
+        return Plugin::$plugin->config->write() ? ExitCode::CANTCREAT : ExitCode::OK;
+    }
+
+    /**
+     * Reads feeds records from file
+     *
+     * @return int
+     */
+    public function actionRead(): int
+    {
+        $result = Plugin::$plugin->config->read();
+
+        if($result->success) {
+            return ExitCode::OK;
+        }
+
+        $this->stderr("FAILED FEEDS" . PHP_EOL, Console::FG_RED);
+        foreach($result->failed_feeds as $feed) {
+            $this->stderr("({$feed->id}) {$feed->name}".PHP_EOL, Console::FG_RED);
+        }
+
+        if(count($result->success_feeds) > 0) {
+            $this->stdout(PHP_EOL . "SUCCESSFUL FEEDS" . PHP_EOL, Console::FG_GREEN);
+            foreach ($result->success_feeds as $feed) {
+                $this->stdout("({$feed->id}) {$feed->name} " . PHP_EOL, Console::FG_GREEN);
+            }
+        }
+
+        return ExitCode::UNSPECIFIED_ERROR;
+    }
+}

--- a/src/console/controllers/FeedsController.php
+++ b/src/console/controllers/FeedsController.php
@@ -9,6 +9,8 @@ use yii\console\Controller;
 use yii\console\ExitCode;
 
 /**
+ * Queues up feed imports
+ *
  * @property Plugin $module
  */
 class FeedsController extends Controller

--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -224,7 +224,7 @@ class Entries extends Field implements FieldInterface
         $element->typeId = $typeId;
 
         $siteId = Hash::get($this->feed, 'siteId');
-        $section = Craft::$app->getSections()->getSectionById($element->sectionId);
+        $section = Craft::$app->getSections()->getSectionByUid($element->sectionUid);
 
         if ($siteId) {
             $element->siteId = $siteId;

--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -224,7 +224,7 @@ class Entries extends Field implements FieldInterface
         $element->typeId = $typeId;
 
         $siteId = Hash::get($this->feed, 'siteId');
-        $section = Craft::$app->getSections()->getSectionByUid($element->sectionUid);
+        $section = $element->getSection();
 
         if ($siteId) {
             $element->siteId = $siteId;

--- a/src/models/FeedModel.php
+++ b/src/models/FeedModel.php
@@ -10,6 +10,8 @@ use craft\feedme\base\Element;
 use craft\feedme\base\ElementInterface;
 use craft\feedme\helpers\DuplicateHelper;
 use craft\feedme\Plugin;
+use craft\helpers\Db;
+use craft\helpers\Json;
 use DateTime;
 
 /**
@@ -253,5 +255,52 @@ class FeedModel extends Model
             [['name', 'feedUrl', 'feedType', 'elementType', 'duplicateHandle', 'passkey'], 'required'],
             [['backup', 'setEmptyValues'], 'boolean'],
         ];
+    }
+
+    /**
+     * Retrieves the attributes in a format for a record
+     *
+     * @return array An array containing the record attributes
+     */
+    public function getRecordAttributes(): array
+    {
+        $attributes = [
+            "name" => $this->name,
+            "feedUrl" => $this->feedUrl,
+            "feedType" => $this->feedType,
+            "primaryElement" => $this->primaryElement,
+            "elementType" => $this->elementType,
+            "siteId" => $this->siteId,
+            "singleton" => $this->singleton,
+            "duplicateHandle" => $this->duplicateHandle,
+            "updateSearchIndexes" => $this->updateSearchIndexes,
+            "paginationNode" => $this->paginationNode,
+            "passkey" => $this->passkey,
+            "backup" => $this->backup,
+            "setEmptyValues" => $this->setEmptyValues,
+
+            // These might be automatically updated, but in the case of writing
+            // the feed record to a file, we want these values.
+            "dateCreated" => Db::prepareDateForDb($this->dateCreated),
+            "dateUpdated" => Db::prepareDateForDb($this->dateUpdated)
+        ];
+
+        if ($this->elementGroup) {
+            $attributes["elementGroup"] = Json::encode($this->elementGroup);
+        }
+
+        if ($this->duplicateHandle) {
+            $attributes["duplicateHandle"] = Json::encode($this->duplicateHandle);
+        }
+
+        if ($this->fieldMapping) {
+            $attributes["fieldMapping"] = Json::encode($this->fieldMapping);
+        }
+
+        if ($this->fieldUnique) {
+            $attributes["fieldUnique"] = Json::encode($this->fieldUnique);
+        }
+
+        return $attributes;
     }
 }

--- a/src/services/DataTypes.php
+++ b/src/services/DataTypes.php
@@ -234,10 +234,15 @@ class DataTypes extends Component
      */
     public function getFeedData($feedModel, bool $usePrimaryElement = true): mixed
     {
-        $feedDataResponse = $feedModel->getDataType()->getFeed($feedModel->feedUrl, $feedModel, $usePrimaryElement);
+        // Dynamism in the feedUrl -- use twig to inject dates, for example
+        $twig = \Craft::$app->getView()->getTwig();
+        $template = twig_template_from_string($twig, $feedModel->feedUrl);
+        $feedUrl = $template->render([]);
+
+        $feedDataResponse = $feedModel->getDataType()->getFeed($feedUrl, $feedModel, $usePrimaryElement);
 
         $event = new FeedDataEvent([
-            'url' => $feedModel->feedUrl,
+            'url' => $feedUrl,
             'response' => $feedDataResponse,
             'feedId' => $feedModel->id,
         ]);

--- a/src/services/DataTypes.php
+++ b/src/services/DataTypes.php
@@ -237,7 +237,7 @@ class DataTypes extends Component
         // Dynamism in the feedUrl -- use twig to inject dates, for example
         $twig = \Craft::$app->getView()->getTwig();
         $template = twig_template_from_string($twig, $feedModel->feedUrl);
-        $feedUrl = $template->render([]);
+        $feedUrl = Craft::getAlias($template->render([]));
 
         $feedDataResponse = $feedModel->getDataType()->getFeed($feedUrl, $feedModel, $usePrimaryElement);
 

--- a/src/services/FeedConfigStorage.php
+++ b/src/services/FeedConfigStorage.php
@@ -42,18 +42,22 @@ class FeedConfigStorage extends Component
     }
 
     /**
-     * Reads feed data from a YAML file and processes each feed.
+     * Reads feed data from a YAML file and imports each feed.
      *
      * @return \stdClass The result object containing success flag, successful feeds, and failed feeds.
      * @throws \yii\base\InvalidConfigException If the configuration is invalid.
      */
     public function read(): \stdClass {
         $result = (object)["success" => true, "success_feeds" => [], "failed_feeds" => []];
+
+        // Delete all feeds
+        foreach(Plugin::getInstance()->getFeeds()->getFeeds() as $feed) {
+            Plugin::getInstance()->getFeeds()->deleteFeedById($feed['id']);
+        }
+        
         $fileName = $this->defaultFileName;
         $feeds = Yaml::parse(file_get_contents($fileName));
         foreach ($feeds as $feed) {
-            Plugin::getInstance()->getFeeds()->deleteFeedById($feed['id']);
-
             $record = new FeedRecord();
             $record->setAttributes($feed, false);
             $record->save(false);

--- a/src/services/FeedConfigStorage.php
+++ b/src/services/FeedConfigStorage.php
@@ -36,7 +36,7 @@ class FeedConfigStorage extends Component
         $fileName = $this->defaultFileName;
         $fileContents = Yaml::dump($feeds, JSON_PRETTY_PRINT);
 
-        mkdir(dirname($this->defaultFileName), 0777, true);
+        if(!file_exists($this->defaultFileName)) mkdir(dirname($this->defaultFileName), 0777, true);
 
         return file_put_contents($fileName, $fileContents) !== false;
     }

--- a/src/services/FeedConfigStorage.php
+++ b/src/services/FeedConfigStorage.php
@@ -3,6 +3,7 @@
 namespace craft\feedme\services;
 
 use craft\base\Component;
+use craft\feedme\models\FeedModel;
 use craft\feedme\Plugin;
 use Symfony\Component\Yaml\Yaml;
 
@@ -52,14 +53,15 @@ class FeedConfigStorage extends Component
         $feeds = Yaml::parse(file_get_contents($fileName));
         foreach ($feeds as $feed) {
             $model = Plugin::getInstance()->getFeeds()->getFeedById($feed['id']);
-            if ($model) {
-                $model->setAttributes($feed);
-                $success = Plugin::getInstance()->getFeeds()->saveFeed($model);
-                if ($success) {
-                    $result->success_feeds[] = $model;
-                } else {
-                    $result->failed_feeds[] = $model;
-                }
+            if (!$model) {
+                $model = new FeedModel();
+            }
+            $model->setAttributes($feed, false);
+            $success = Plugin::getInstance()->getFeeds()->saveFeed($model);
+            if ($success) {
+                $result->success_feeds[] = $model;
+            } else {
+                $result->failed_feeds[] = $model;
             }
         }
 

--- a/src/services/FeedConfigStorage.php
+++ b/src/services/FeedConfigStorage.php
@@ -3,8 +3,8 @@
 namespace craft\feedme\services;
 
 use craft\base\Component;
-use craft\feedme\models\FeedModel;
 use craft\feedme\Plugin;
+use craft\feedme\records\FeedRecord;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -52,16 +52,16 @@ class FeedConfigStorage extends Component
         $fileName = $this->defaultFileName;
         $feeds = Yaml::parse(file_get_contents($fileName));
         foreach ($feeds as $feed) {
-            $model = Plugin::getInstance()->getFeeds()->getFeedById($feed['id']);
-            if (!$model) {
-                $model = new FeedModel();
-            }
-            $model->setAttributes($feed, false);
-            $success = Plugin::getInstance()->getFeeds()->saveFeed($model);
+            Plugin::getInstance()->getFeeds()->deleteFeedById($feed['id']);
+
+            $record = new FeedRecord();
+            $record->setAttributes($feed, false);
+            $record->save(false);
+            $success = (bool) $record->id;
             if ($success) {
-                $result->success_feeds[] = $model;
+                $result->success_feeds[] = $record;
             } else {
-                $result->failed_feeds[] = $model;
+                $result->failed_feeds[] = $record;
             }
         }
 

--- a/src/services/FeedConfigStorage.php
+++ b/src/services/FeedConfigStorage.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace craft\feedme\services;
+
+use craft\base\Component;
+use craft\feedme\Plugin;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ *
+ *
+ */
+class FeedConfigStorage extends Component
+{
+    /**
+     * @var string $defaultFileName The default file name for the feeds configuration.
+     */
+    protected $defaultFileName = "config/feed-me/feeds.yaml";
+
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * Writes the feeds data to a YAML file.
+     *
+     * @return bool True if the data was successfully written to the file, false otherwise.
+     * @throws \yii\base\InvalidConfigException If the plugin instance is not properly configured.
+     */
+    public function write(): bool {
+        $feeds = array_map(
+            function($feed) { return ["id" => $feed->id] + $feed->getRecordAttributes(); },
+            Plugin::getInstance()->getFeeds()->getFeeds()
+        );
+
+        $fileName = $this->defaultFileName;
+        $fileContents = Yaml::dump($feeds, JSON_PRETTY_PRINT);
+
+        return file_put_contents($fileName, $fileContents) !== false;
+    }
+
+    /**
+     * Reads feed data from a YAML file and processes each feed.
+     *
+     * @return \stdClass The result object containing success flag, successful feeds, and failed feeds.
+     * @throws \yii\base\InvalidConfigException If the configuration is invalid.
+     */
+    public function read(): \stdClass {
+        $result = (object)["success" => true, "success_feeds" => [], "failed_feeds" => []];
+        $fileName = $this->defaultFileName;
+        $feeds = Yaml::parse(file_get_contents($fileName));
+        foreach ($feeds as $feed) {
+            $model = Plugin::getInstance()->getFeeds()->getFeedById($feed['id']);
+            if ($model) {
+                $model->setAttributes($feed);
+                $success = Plugin::getInstance()->getFeeds()->saveFeed($model);
+                if ($success) {
+                    $result->success_feeds[] = $model;
+                } else {
+                    $result->failed_feeds[] = $model;
+                }
+            }
+        }
+
+        if(count($result->failed_feeds) > 0) {
+            $result->success = false;
+        }
+
+        return $result;
+    }
+}

--- a/src/services/FeedConfigStorage.php
+++ b/src/services/FeedConfigStorage.php
@@ -35,6 +35,8 @@ class FeedConfigStorage extends Component
         $fileName = $this->defaultFileName;
         $fileContents = Yaml::dump($feeds, JSON_PRETTY_PRINT);
 
+        mkdir(dirname($this->defaultFileName), 0777, true);
+
         return file_put_contents($fileName, $fileContents) !== false;
     }
 

--- a/src/services/Feeds.php
+++ b/src/services/Feeds.php
@@ -119,30 +119,8 @@ class Feeds extends Component
             }
         }
 
-        $record->name = $model->name;
-        $record->feedUrl = $model->feedUrl;
-        $record->feedType = $model->feedType;
-        $record->primaryElement = $model->primaryElement;
-        $record->elementType = $model->elementType;
-        $record->siteId = $model->siteId;
-        $record->singleton = $model->singleton;
-        $record->duplicateHandle = $model->duplicateHandle;
-        $record->updateSearchIndexes = $model->updateSearchIndexes;
-        $record->paginationNode = $model->paginationNode;
-        $record->passkey = $model->passkey;
-        $record->backup = $model->backup;
-        $record->setEmptyValues = $model->setEmptyValues;
-
-        if ($model->elementGroup) {
-            $record->setAttribute('elementGroup', Json::encode($model->elementGroup));
-        }
-
-        if ($model->fieldMapping) {
-            $record->setAttribute('fieldMapping', Json::encode($model->fieldMapping));
-        }
-
-        if ($model->fieldUnique) {
-            $record->setAttribute('fieldUnique', Json::encode($model->fieldUnique));
+        foreach($model->getRecordAttributes() as $name => $value) {
+            $record->setAttribute($name, $value);
         }
 
         if ($isNewModel) {

--- a/src/templates/_includes/elements/entries/column.html
+++ b/src/templates/_includes/elements/entries/column.html
@@ -1,9 +1,9 @@
-{% set sectionId = feed.elementGroup[elementType].section %}
-{% set entryTypeId = feed.elementGroup[elementType].entryType %}
+{% set sectionUid = feed.elementGroup[elementType].section %}
+{% set entryTypeUid = feed.elementGroup[elementType].entryType %}
 
-{% if sectionId and entryTypeId %}
-    {% set section = craft.app.sections.getSectionById(sectionId) %}
-    {% set entryType = craft.app.sections.getEntryTypeById(entryTypeId) %}
+{% if sectionUid and entryTypeUid %}
+    {% set section = craft.app.sections.getSectionByUid(sectionUid) %}
+    {% set entryType = craft.app.sections.getEntryTypeByUid(entryTypeUid) %}
 
     {% if section and entryType %}
         <span class="element-group">{{ section.name }}</span>

--- a/src/templates/_includes/elements/entries/groups.html
+++ b/src/templates/_includes/elements/entries/groups.html
@@ -7,24 +7,22 @@
 {# Create a section-indexed array of element types #}
 {% set entryTypes = [] %}
 {% for section in sections %}
-    {% set options = craft.feedme.getSelectOptions(section.model.getEntryTypes()) %}
-
+    {% set options = craft.feedme.getSelectOptions(section.model.getEntryTypes(), 'name', 'uid') %}
     {# We have to prefix the index, otherwise Twig doesn't maintain numbered index correctly #}
-    {% set entryTypes = entryTypes|merge({ ('item_' ~ section.id): options }) %}
+    {% set entryTypes = entryTypes|merge({ ('item_' ~ section.model.uid): options }) %}
 {% endfor %}
 
-{% set sectionId = null %}
-{% set entryTypeId = null %}
+{% set sectionUid = null %}
+{% set entryTypeUid = null %}
 
 {# Load saved values for feed #}
 {% if feed.elementGroup[elementType] is defined %}
-    {% set sectionId = feed.elementGroup[elementType].section ?? null %}
-    {% set entryTypeId = feed.elementGroup[elementType].entryType ?? null %}
+    {% set sectionUid = feed.elementGroup[elementType].section ?? null %}
+    {% set entryTypeUid = feed.elementGroup[elementType].entryType ?? null %}
 {% endif %}
 
-{% if sectionId %}
-    {% set section = craft.app.sections.getSectionById(sectionId) %}
-
+{% if sectionUid %}
+    {% set section = craft.app.sections.getSectionByUid(sectionUid) %}
     {% if section %}
         {% set sectionEntryTypes = section.getEntryTypes() %}
     {% endif %}
@@ -39,8 +37,8 @@
         class: 'element-parent-group',
         id: 'elementGroup-' ~ elementType ~ '-section',
         name: 'elementGroup[' ~ elementType ~ '][section]',
-        options: craft.feedme.getSelectOptions(sections|map(s => s.model)),
-        value: sectionId ?? '',
+        options: craft.feedme.getSelectOptions(sections|map(s => s.model), 'name', 'uid'),
+        value: sectionUid ?? '',
         errors: feed.getErrors('elementGroup'),
         required: true,
     }) }}
@@ -51,8 +49,8 @@
         class: 'element-child-group',
         id: 'elementGroup-' ~ elementType ~ '-entryType',
         name: 'elementGroup[' ~ elementType ~ '][entryType]',
-        options: craft.feedme.getSelectOptions(sectionEntryTypes),
-        value: entryTypeId ?? '',
+        options: craft.feedme.getSelectOptions(sectionEntryTypes, 'name', 'uid'),
+        value: entryTypeUid ?? '',
         errors: feed.getErrors('elementGroup'),
         required: true,
     }) }}

--- a/src/templates/_includes/elements/entries/map.html
+++ b/src/templates/_includes/elements/entries/map.html
@@ -2,11 +2,11 @@
 {% import 'feed-me/_macros' as feedMeMacro %}
 
 {% if feed.elementGroup %}
-    {% set sectionId = feed.elementGroup[feed.elementType].section %}
-    {% set entryTypeId = feed.elementGroup[feed.elementType].entryType %}
+    {% set sectionUid = feed.elementGroup[feed.elementType].section %}
+    {% set entryTypeUid = feed.elementGroup[feed.elementType].entryType %}
 
-    {% set section = craft.app.sections.getSectionById(sectionId) %}
-    {% set entryType = craft.app.sections.getEntryTypeById(entryTypeId) %}
+    {% set section = craft.app.sections.getSectionByUid(sectionUid) %}
+    {% set entryType = craft.app.sections.getEntryTypeByUid(entryTypeUid) %}
 {% endif %}
 
 


### PR DESCRIPTION
### Description

This is the beginning of an idea to read / write feed configuration from / to the filesystem. This allows feeds to be tracked in the filesystem, like any other configuration or code. Developers will be able to create the feeds locally, write the feed to the filesystem using `./craft feed-me/feed-config-storage/write`, commit that file, and, as a deploy step, read the configuration from disk with `./craft feed-me/feed-config-storage/read`.

This hasn't been fully tested. I assume there are glaring bugs. Is this a feature that might be considered valuable enough to be incorporated into the plugin, or are we unique in this need? We can, but prefer not to, maintain our own fork, but I'd rather share this work with others.

I'm curious to hear your thoughts and whether you can offer any course corrections or other feedback. Thanks!

Note: you will need to `mkdir config/feed-me` for this to work at the moment.

