### PR TITLE
Loosen `nesbot/carbon` requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "craftcms/cms": "^5.0.0-beta.2",
     "cakephp/utility": "^5.0.0",
     "jakeasmith/http_build_url": "^1.0",
-    "nesbot/carbon": "^3.0.0",
+    "nesbot/carbon": "^2.10|^3.0.0",
     "league/csv": "^9.0",
     "seld/jsonlint": "^1.7"
   },


### PR DESCRIPTION
This PR loosens the requirement for `nesbot/carbon`, which is required by other plugins when installing `illuminate/support:^10.0`.
https://packagist.org/packages/illuminate/support#10.x-dev