### PR TITLE
Fix #1427

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed a bug when importing Assets ([#1427](https://github.com/craftcms/feed-me/pull/1410))
+- Fixed a bug when importing Assets ([#1427](https://github.com/craftcms/feed-me/pull/1427))
 
 ## 6.0.0 - 2024-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Feed Me
 
+## Unreleased
+
+- Fixed a bug when importing Assets ([#1427](https://github.com/craftcms/feed-me/pull/1410))
+
 ## 6.0.0 - 2024-03-19
 
 - Feed Me now requires Craft CMS 5.0.0-beta.2 or later.

--- a/src/helpers/AssetHelper.php
+++ b/src/helpers/AssetHelper.php
@@ -117,7 +117,7 @@ class AssetHelper
         $asset->folderId = $folder->id;
         $asset->folderPath = $folder->path;
         $asset->volumeId = $volume->id;
-        $targetUrl = AssetsHelper::generateUrl($volume->getFs(), $asset);
+        $targetUrl = AssetsHelper::generateUrl($asset);
 
         $rootUrl = $volume->getRootUrl() ?? '';
         $targetPath = str_replace($rootUrl, '', $targetUrl);


### PR DESCRIPTION
`\craft\helpers\Assets::generateUrl` no longer takes an FS as first argument (see [here](https://github.com/craftcms/cms/pull/14353)). Craft 5/Feed Me 6 only.

