### PR TITLE
better check for when we're falling back on a default BaseRelationField value

### DIFF
--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -145,7 +145,7 @@ class Assets extends Field implements FieldInterface
 
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if (trim($dataValue) === '') {
+            if (DataHelper::isArrayValueEmpty($value)) {
                 $foundElements = $default;
                 break;
             }

--- a/src/fields/CalendarEvents.php
+++ b/src/fields/CalendarEvents.php
@@ -102,7 +102,7 @@ class CalendarEvents extends Field implements FieldInterface
 
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if (trim($dataValue) === '') {
+            if (DataHelper::isArrayValueEmpty($value)) {
                 $foundElements = $default;
                 break;
             }

--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -111,7 +111,7 @@ class Categories extends Field implements FieldInterface
 
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if (trim($dataValue) === '') {
+            if (DataHelper::isArrayValueEmpty($value)) {
                 $foundElements = $default;
                 break;
             }

--- a/src/fields/CommerceProducts.php
+++ b/src/fields/CommerceProducts.php
@@ -107,7 +107,7 @@ class CommerceProducts extends Field implements FieldInterface
 
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if (trim($dataValue) === '') {
+            if (DataHelper::isArrayValueEmpty($value)) {
                 $foundElements = $default;
                 break;
             }

--- a/src/fields/CommerceVariants.php
+++ b/src/fields/CommerceVariants.php
@@ -106,7 +106,7 @@ class CommerceVariants extends Field implements FieldInterface
 
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if (trim($dataValue) === '') {
+            if (DataHelper::isArrayValueEmpty($value)) {
                 $foundElements = $default;
                 break;
             }

--- a/src/fields/DigitalProducts.php
+++ b/src/fields/DigitalProducts.php
@@ -107,7 +107,7 @@ class DigitalProducts extends Field implements FieldInterface
 
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if (trim($dataValue) === '') {
+            if (DataHelper::isArrayValueEmpty($value)) {
                 $foundElements = $default;
                 break;
             }

--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -122,7 +122,7 @@ class Entries extends Field implements FieldInterface
 
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if (trim($dataValue) === '') {
+            if (DataHelper::isArrayValueEmpty($value)) {
                 $foundElements = $default;
                 break;
             }

--- a/src/fields/Tags.php
+++ b/src/fields/Tags.php
@@ -105,7 +105,7 @@ class Tags extends Field implements FieldInterface
 
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if (trim($dataValue) === '') {
+            if (DataHelper::isArrayValueEmpty($value)) {
                 $foundElements = $default;
                 break;
             }

--- a/src/fields/Users.php
+++ b/src/fields/Users.php
@@ -131,7 +131,7 @@ class Users extends Field implements FieldInterface
 
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if (trim($dataValue) === '') {
+            if (DataHelper::isArrayValueEmpty($value)) {
                 $foundElements = $default;
                 break;
             }


### PR DESCRIPTION
### Description
It’s already possible to import multiple values into fields that extend `BaseRelationField`.

In a case where in the feed you have a key with an empty array value, you map that empty array value to a `BaseRelationField`, and you select a “Default <Element>” too (on the mapping screen), the current check assumes you’ve set the feed value to `null`, and fails when you’ve set it to an empty array. This PR improves this behaviour.


### Related issues
#1432 
