### PR TITLE
matching elements on custom fields

### DIFF
--- a/src/elements/CalenderEvent.php
+++ b/src/elements/CalenderEvent.php
@@ -217,10 +217,12 @@ class CalenderEvent extends Element
         if ($match === 'fullName') {
             $element = UserElement::findOne(['search' => $value, 'status' => null]);
         } else {
-            $element = UserElement::find()
-                ->status(null)
-                ->andWhere(['=', $match, $value])
-                ->one();
+            $query = UserElement::find()
+                ->status(null);
+
+            // using $query->andWhere() doesn't work for custom fields
+            Craft::configure($query, [$match => $value]);
+            $element = $query->one();
         }
 
         if ($element) {

--- a/src/elements/Category.php
+++ b/src/elements/Category.php
@@ -155,8 +155,7 @@ class Category extends Element
         }
 
         $query = CategoryElement::find()
-            ->status(null)
-            ->andWhere(['=', $match, $value]);
+            ->status(null);
 
         if (isset($this->feed['siteId']) && $this->feed['siteId']) {
             $query->siteId($this->feed['siteId']);
@@ -167,6 +166,8 @@ class Category extends Element
             $query->groupId($this->element->groupId);
         }
 
+        // using $query->andWhere() doesn't work for custom fields
+        Craft::configure($query, [$match => $value]);
         $element = $query->one();
 
         if ($element) {

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -247,8 +247,7 @@ class Entry extends Element
         }
 
         $query = EntryElement::find()
-            ->status(null)
-            ->andWhere(['=', $match, $value]);
+            ->status(null);
 
         if (isset($this->feed['siteId']) && $this->feed['siteId']) {
             $query->siteId($this->feed['siteId']);
@@ -259,6 +258,8 @@ class Entry extends Element
             $query->sectionId($this->element->sectionId);
         }
 
+        // using $query->andWhere() doesn't work for custom fields
+        Craft::configure($query, [$match => $value]);
         $element = $query->one();
 
         if ($element) {
@@ -326,10 +327,12 @@ class Entry extends Element
             if ($match === 'fullName') {
                 $element = UserElement::findOne(['search' => $value, 'status' => null]);
             } else {
-                $element = UserElement::find()
-                    ->status(null)
-                    ->andWhere(['=', $match, $value])
-                    ->one();
+                $query = UserElement::find()
+                    ->status(null);
+
+                // using $query->andWhere() doesn't work for custom fields
+                Craft::configure($query, [$match => $value]);
+                $element = $query->one();
             }
 
             if ($element) {


### PR DESCRIPTION
### Description
Matching elements (e.g. entry parent, entry author) based on a custom field was throwing an SQL error. I switched the queries to go via `Craft::configure()` which fixes the problem.


### Related issues
#1422 
