### PR TITLE
when mapping to match elements by id, don't use the elements prefix

### DIFF
--- a/src/templates/_includes/fields/calendar-events.html
+++ b/src/templates/_includes/fields/calendar-events.html
@@ -34,7 +34,7 @@
             value: hash_get(feed.fieldMapping, optionsPath ~ '.match') ?: '',
             options: [
                 { value: 'title', label: 'Title'|t('feed-me') },
-                { value: 'elements.id', label: 'ID'|t('feed-me') },
+                { value: 'id', label: 'ID'|t('feed-me') },
                 { value: 'slug', label: 'Slug'|t('feed-me') },
             ],
         }) }}

--- a/src/templates/_includes/fields/categories.html
+++ b/src/templates/_includes/fields/categories.html
@@ -42,7 +42,7 @@
 
         {% set matchAttributes = [
             { value: 'title', label: 'Title'|t('feed-me') },
-            { value: 'elements.id', label: 'ID'|t('feed-me') },
+            { value: 'id', label: 'ID'|t('feed-me') },
             { value: 'slug', label: 'Slug'|t('feed-me') },
         ] %}
 

--- a/src/templates/_includes/fields/commerce_products.html
+++ b/src/templates/_includes/fields/commerce_products.html
@@ -34,7 +34,7 @@
             value: hash_get(feed.fieldMapping, optionsPath ~ '.match') ?: '',
             options: [
                 { value: 'title', label: 'Title'|t('feed-me') },
-                { value: 'elements.id', label: 'ID'|t('feed-me') },
+                { value: 'id', label: 'ID'|t('feed-me') },
                 { value: 'slug', label: 'Slug'|t('feed-me') },
             ],
         }) }}

--- a/src/templates/_includes/fields/commerce_variants.html
+++ b/src/templates/_includes/fields/commerce_variants.html
@@ -34,7 +34,7 @@
             value: hash_get(feed.fieldMapping, optionsPath ~ '.match') ?: '',
             options: [
                 { value: 'title', label: 'Title'|t('feed-me') },
-                { value: 'elements.id', label: 'ID'|t('feed-me') },
+                { value: 'id', label: 'ID'|t('feed-me') },
                 { value: 'sku', label: 'SKU'|t('feed-me') },
             ],
         }) }}

--- a/src/templates/_includes/fields/digital-products.html
+++ b/src/templates/_includes/fields/digital-products.html
@@ -34,7 +34,7 @@
             value: hash_get(feed.fieldMapping, optionsPath ~ '.match') ?: '',
             options: [
                 { value: 'title', label: 'Title'|t('feed-me') },
-                { value: 'elements.id', label: 'ID'|t('feed-me') },
+                { value: 'id', label: 'ID'|t('feed-me') },
                 { value: 'slug', label: 'Slug'|t('feed-me') },
             ],
         }) }}

--- a/src/templates/_includes/fields/element.html
+++ b/src/templates/_includes/fields/element.html
@@ -19,7 +19,7 @@
 
         {% set matchAttributes = [
             { value: 'title', label: 'Title'|t('feed-me') },
-            { value: 'elements.id', label: 'ID'|t('feed-me') },
+            { value: 'id', label: 'ID'|t('feed-me') },
             { value: 'slug', label: 'Slug'|t('feed-me') },
         ] %}
 

--- a/src/templates/_includes/fields/entries.html
+++ b/src/templates/_includes/fields/entries.html
@@ -44,7 +44,7 @@
 
         {% set matchAttributes = [
             { value: 'title', label: 'Title'|t('feed-me') },
-            { value: 'elements.id', label: 'ID'|t('feed-me') },
+            { value: 'id', label: 'ID'|t('feed-me') },
             { value: 'slug', label: 'Slug'|t('feed-me') },
         ] %}
 

--- a/src/templates/_includes/fields/users.html
+++ b/src/templates/_includes/fields/users.html
@@ -42,7 +42,7 @@
 
         {% set matchAttributes = [
             { value: 'email', label: 'Email'|t('feed-me') },
-            { value: 'elements.id', label: 'ID'|t('feed-me') },
+            { value: 'id', label: 'ID'|t('feed-me') },
             { value: 'username', label: 'Username'|t('feed-me') },
             { value: 'fullName', label: 'Full Name'|t('feed-me') },
         ] %}


### PR DESCRIPTION
### Description
For the relation fields, don’t use the `elements` prefix when mapping to match elements by id.


### Related issues
#1438 
