### PR TITLE
fill the gaps before comparing content

### DIFF
--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -174,6 +174,15 @@ class Categories extends Field implements FieldInterface
 
         $foundElements = array_unique($foundElements);
 
+        // if the field has maintainHierarchy on, and we're supposed to compare content,
+        // we need to fill in the gaps, so that we know if the content has truly changed
+        // https://github.com/craftcms/feed-me/issues/1418
+        if ($foundElements && $maintainHierarchy && Plugin::$plugin->service->getConfig('compareContent', $this->feed['id'])) {
+            $elements = CategoryElement::find()->id($foundElements)->all();
+            Craft::$app->getStructures()->fillGapsInElements($elements);
+            $foundElements = array_map(fn($element) => $element->id, $elements);
+        }
+
         // Protect against sending an empty array - removing any existing elements
         if (!$foundElements) {
             return null;

--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -79,9 +79,14 @@ class Entries extends Field implements FieldInterface
         }
 
         $sources = Hash::get($this->field, 'settings.sources');
-        $limit = Hash::get($this->field, 'settings.maxRelations');
-        $targetSiteId = Hash::get($this->field, 'settings.targetSiteId');
         $maintainHierarchy = Hash::get($this->field, 'settings.maintainHierarchy');
+        if ($maintainHierarchy) {
+            $limit = Hash::get($this->field, 'settings.branchLimit');
+        } else {
+            $limit = Hash::get($this->field, 'settings.maxRelations');
+        }
+
+        $targetSiteId = Hash::get($this->field, 'settings.targetSiteId');
         $feedSiteId = Hash::get($this->feed, 'siteId');
         $create = Hash::get($this->fieldInfo, 'options.create');
         $fields = Hash::get($this->fieldInfo, 'fields');


### PR DESCRIPTION
### Description
For the relation fields that have maintain hierarchy set to `true`, (and if `compareContent` is on), fill the gaps when parsing the incoming value so that comparing content doesn't return false positives.


### Related issues
#1418 
