### PR TITLE
multi-select - numeric values shouldn't be treated as empty

### DIFF
--- a/src/fields/MultiSelect.php
+++ b/src/fields/MultiSelect.php
@@ -63,7 +63,7 @@ class MultiSelect extends Field implements FieldInterface
                 continue;
             }
             foreach ($value as $dataValue) {
-                if (!empty($dataValue) && $dataValue === $option[$match]) {
+                if ((!empty($dataValue) || is_numeric($dataValue)) && $dataValue === $option[$match]) {
                     $preppedData[] = $option['value'];
                 }
                 // special case for when mapping by label, but also using a default value


### PR DESCRIPTION
### Description
When importing into a multi-select, treat numeric values as not empty.

I also checked checkboxes, dropdown and radio fields, and they are all already capable of matching on a numeric zero value/label.


### Related issues
#1413 
