### PR TITLE
direct feed - adjust title based on success

### DIFF
--- a/src/templates/feeds/_direct.html
+++ b/src/templates/feeds/_direct.html
@@ -7,7 +7,7 @@
     <!-- Responsive-ness -->
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ 'Feed Me - {name} has started processing'|t('feed-me', { name: feed.name }) }}</title>
+    <title>{{ task ? 'Feed Me - {name} has started processing'|t('feed-me', { name: feed.name }) : 'Unable to start feed'|t('feed-me') }}</title>
 
     <!-- CSS -->
 </head>


### PR DESCRIPTION
### Description
When initiating a feed via direct URL, if the feed processing can’t be started (e.g., because the passkey is not correct), change the value of the title tag to indicate a failure and don’t leak the feed’s name.


### Related issues
#1407 
