### PR TITLE
Bugfix/1403 comparing values

### DIFF
--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -445,6 +445,14 @@ class DataHelper
             return true;
         }
 
+        // check if both empty
+        if (
+            (!is_numeric($firstValue) && !is_bool($firstValue) && empty($firstValue)) &&
+            (!is_numeric($secondValue) && !is_bool($secondValue) && empty($secondValue))
+        ) {
+            return true;
+        }
+
         // Didn't match
         return false;
     }
@@ -463,10 +471,10 @@ class DataHelper
         if (is_array($firstValue) && is_array($secondValue)) {
             // Ignore values that are `null` or empty arrays
             $firstValue = array_filter($firstValue, static function($value) {
-                return !($value === null || $value === []);
+                return !($value === null || $value === '' || $value === []);
             });
             $secondValue = array_filter($secondValue, static function($value) {
-                return !($value === null || $value === []);
+                return !($value === null || $value === '' || $value === []);
             });
 
             // Both values must have the same keys (ignoring order)

--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -264,20 +264,7 @@ class DataHelper
         foreach ($content as $key => $newValue) {
             $existingValue = Hash::get($fields, $key);
 
-            // If date value, make sure to cast it as a string to compare
-            if ($existingValue instanceof \DateTime || DateTimeHelper::isIso8601($existingValue)) {
-                $existingValue = Db::prepareDateForDb($existingValue);
-            }
-
-            // If date value, make sure to cast it as a string to compare
-            if ($newValue instanceof DateTime || DateTimeHelper::isIso8601($newValue)) {
-                $newValue = Db::prepareDateForDb($newValue);
-            }
-
-            // If an empty 'date' value, it's the same as null
-            if (is_array($newValue) && isset($newValue['date']) && $newValue['date'] === '') {
-                $newValue = null;
-            }
+            [$existingValue, $newValue] = self::prepDatesForComparison($existingValue, $newValue);
 
             // If array key & values are already within the existing array
             if (is_array($newValue) && is_array($existingValue) && Hash::contains($existingValue,$newValue)) {
@@ -345,6 +332,33 @@ class DataHelper
         }
 
         return empty($trackedChanges);
+    }
+
+    /**
+     * Prepare dates for comparison.
+     *
+     * @param mixed $firstValue
+     * @param mixed $secondValue
+     * @return array
+     */
+    public static function prepDatesForComparison(mixed $firstValue, mixed $secondValue): array
+    {
+        // If date value, make sure to cast it as a string to compare
+        if ($firstValue instanceof \DateTime || DateTimeHelper::isIso8601($firstValue)) {
+            $firstValue = Db::prepareDateForDb($firstValue);
+        }
+
+        // If date value, make sure to cast it as a string to compare
+        if ($secondValue instanceof DateTime || DateTimeHelper::isIso8601($secondValue)) {
+            $secondValue = Db::prepareDateForDb($secondValue);
+        }
+
+        // If an empty 'date' value, it's the same as null
+        if (is_array($secondValue) && isset($secondValue['date']) && $secondValue['date'] === '') {
+            $secondValue = null;
+        }
+
+        return [$firstValue, $secondValue];
     }
 
     /**
@@ -444,6 +458,8 @@ class DataHelper
      */
     private static function _recursiveCompare($firstValue, $secondValue): bool
     {
+        [$firstValue, $secondValue] = self::prepDatesForComparison($firstValue, $secondValue);
+
         if (is_array($firstValue) && is_array($secondValue)) {
             // Ignore values that are `null` or empty arrays
             $firstValue = array_filter($firstValue, static function($value) {


### PR DESCRIPTION
### Description
I’ve extrapolated the logic of preparing dates for comparison into a separate method and started using it in both `compareElementContent` and `_recursiveCompare` (when comparing complex values).

I’ve adjusted the comparison of empty values so that if the existing value is, for example, null and the new value is empty (but not null), the data is not unnecessarily reported as changed.

All the hard work done by @jeffreyzant - thanks!


### Related issues
#1403 

