### PR TITLE
increase fieldMapping column size to mediumtext

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -62,7 +62,7 @@ class Plugin extends \craft\base\Plugin
     }
 
     public string $minVersionRequired = '4.4.8';
-    public string $schemaVersion = '5.1.0.0';
+    public string $schemaVersion = '5.1.0.1';
     public bool $hasCpSettings = true;
     public bool $hasCpSection = true;
 

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -42,7 +42,7 @@ class Install extends Migration
             'duplicateHandle' => $this->text(),
             'updateSearchIndexes' => $this->boolean()->notNull()->defaultValue(true),
             'paginationNode' => $this->text(),
-            'fieldMapping' => $this->text(),
+            'fieldMapping' => $this->mediumText(),
             'fieldUnique' => $this->text(),
             'passkey' => $this->string()->notNull(),
             'backup' => $this->boolean()->notNull()->defaultValue(false),

--- a/src/migrations/m240523_145259_field_mapping_column_change.php
+++ b/src/migrations/m240523_145259_field_mapping_column_change.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace craft\feedme\migrations;
+
+use Craft;
+use craft\db\Migration;
+
+/**
+ * m240523_145259_field_mapping_column_change migration.
+ */
+class m240523_145259_field_mapping_column_change extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        if ($this->db->columnExists('{{%feedme_feeds}}', 'fieldMapping')) {
+            $this->alterColumn('{{%feedme_feeds}}', 'fieldMapping', $this->mediumText());
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        if ($this->db->columnExists('{{%feedme_feeds}}', 'fieldMapping')) {
+            $this->alterColumn('{{%feedme_feeds}}', 'fieldMapping', $this->text());
+        }
+
+        return true;
+    }
+}

--- a/src/migrations/m240523_145259_field_mapping_column_change.php
+++ b/src/migrations/m240523_145259_field_mapping_column_change.php
@@ -2,7 +2,6 @@
 
 namespace craft\feedme\migrations;
 
-use Craft;
 use craft\db\Migration;
 
 /**


### PR DESCRIPTION
### Description
Migrate the `fieldMapping` column in the `feedme_feeds` table from `text` to `mediumtext` to help store mapping info for larger layouts when using Maria/MySQL. PostgreSQL will stay as text (as it doesn’t have the same limit on the text type and also doesn’t have a mediumtext type).


### Related issues
#1446 
