### PR TITLE
Account for backupCommand === false

### DIFF
--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -644,6 +644,11 @@ class Process extends Component
      */
     private function _backupBeforeFeed($feed): void
     {
+        if (Craft::$app->getConfig()->getGeneral()->backupCommand === false) {
+            Plugin::info('Database not backed up because the backup command is false.');
+            return;
+        }
+
         $logKey = StringHelper::randomString(20);
 
         $limit = Plugin::$plugin->service->getConfig('backupLimit', $feed['id']);

--- a/src/templates/feeds/_edit.html
+++ b/src/templates/feeds/_edit.html
@@ -21,6 +21,7 @@
 {% set title = (feed.id) ? feed.name : 'Create a new feed'|t('feed-me') %}
 {% set noTabs = true %}
 {% set fullPageForm = true %}
+{% set backupsDisabled = craft.app.config.general.backupCommand is same as(false)  %}
 
 {% set buttons %}
     <div class="buttons">
@@ -206,6 +207,9 @@
         instructions: 'Perform a full backup each time this feed is processed.'|t('feed-me'),
         name: 'backup',
         on: (feed.id) ? feed.backup : true,
+        containerAttributes: backupsDisabled ? {class: ['disabled']} : {},
+        tip: backupsDisabled ? 'Backups are disabled while the backup command is `false`.'|t('feed-me'),
+        disabled: backupsDisabled,
     }) }}
 
     {{ forms.lightswitchField({


### PR DESCRIPTION
### Description
When `backupCommand === false`,:
- logs an info message, bypasses backup
- disables the lightswitch that controls this feed setting

![CleanShot 2024-06-11 at 09 33 00@2x](https://github.com/craftcms/feed-me/assets/18329/cfffd121-c56e-4566-935e-ddd3dcbb541a)