### PR TITLE
Convert to Yii log targets and use DbTarget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed an error that would occur when running a feed with the backup database setting enabled, when Craft's `backupCommand` was set to false. ([#1461](https://github.com/craftcms/feed-me/pull/1461))
+- Logs now use the default log component, and are stored in the database. [#1344](https://github.com/craftcms/feed-me/issues/1344)
 
 ## 5.5.0 - 2024-05-26
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,33 @@ composer require craftcms/feed-me
 ./craft plugin/install feed-me
 ```
 
+## Customizing Logs
+
+As of version `5.6`/`6.2`, logging is handled by Craft's log component and stored in the database instead of the filesystem.
+If you want them logged to files (or anywhere else), you can add your own log target in your `config/app.php` file:
+
+```php
+return [
+    'components' => [
+        'log' => [
+            'monologTargetConfig' => [
+                // optionally, omit from Craft's default logs
+                'except' => ['feed-me'],
+            ],
+            
+            // add your own log target to write logs to file
+            'targets' => [
+                [
+                    'class' => \yii\log\FileTarget::class,
+                    'logFile' => '@storage/logs/feed-me.log',
+                    'categories' => ['feed-me'],
+                ],
+            ],
+        ],
+    ],
+];
+```
+
 ## Resources
 
 - **[Feed Me Plugin Page](https://plugins.craftcms.com/feed-me)** – The official plugin page for Feed Me

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -52,10 +52,24 @@ class Install extends Migration
             'dateUpdated' => $this->dateTime()->notNull(),
             'uid' => $this->uid(),
         ]);
+
+        // @see \craft\feedme\migrations\m240611_134740_create_logs_table
+        $this->createTable('{{%feedme_logs}}', [
+            'id' => $this->bigPrimaryKey(),
+            'level' => $this->integer(),
+            'category' => $this->string(),
+            'log_time' => $this->double(),
+            'prefix' => $this->text(),
+            'message' => $this->text(),
+        ]);
+
+        $this->createIndex('idx_log_level', '{{%feedme_logs}}', 'level');
+        $this->createIndex('idx_log_category', '{{%feedme_logs}}', 'category');
     }
 
     protected function removeTables(): void
     {
         $this->dropTableIfExists('{{%feedme_feeds}}');
+        $this->dropTableIfExists('{{%feedme_logs}}');
     }
 }

--- a/src/migrations/m240611_134740_create_logs_table.php
+++ b/src/migrations/m240611_134740_create_logs_table.php
@@ -9,19 +9,13 @@ use craft\db\Migration;
  */
 class m240611_134740_create_logs_table extends Migration
 {
-    public const LOG_TABLE = '{{%feedme_logs}}';
-
     /**
      * @inheritdoc
      */
     public function safeUp(): bool
     {
-        if ($this->db->tableExists(self::LOG_TABLE)) {
-            return true;
-        }
-
         // @see \craft\feedme\migrations\m240611_134740_create_logs_table
-        $this->createTable(self::LOG_TABLE, [
+        $this->createTable('{{%feedme_logs}}', [
             'id' => $this->bigPrimaryKey(),
             'level' => $this->integer(),
             'category' => $this->string(),
@@ -30,8 +24,8 @@ class m240611_134740_create_logs_table extends Migration
             'message' => $this->text(),
         ]);
 
-        $this->createIndex('idx_log_level', self::LOG_TABLE, 'level');
-        $this->createIndex('idx_log_category', self::LOG_TABLE, 'category');
+        $this->createIndex('idx_log_level', '{{%feedme_logs}}', 'level');
+        $this->createIndex('idx_log_category', '{{%feedme_logs}}', 'category');
 
         return true;
     }
@@ -41,9 +35,7 @@ class m240611_134740_create_logs_table extends Migration
      */
     public function safeDown(): bool
     {
-        if ($this->db->tableExists(self::LOG_TABLE)) {
-            $this->dropTable(self::LOG_TABLE);
-        }
+        $this->dropTableIfExists('{{%feedme_logs}}');
 
         return true;
     }

--- a/src/migrations/m240611_134740_create_logs_table.php
+++ b/src/migrations/m240611_134740_create_logs_table.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace craft\feedme\migrations;
+
+use craft\db\Migration;
+
+/**
+ * m240611_134740_create_logs_table migration.
+ */
+class m240611_134740_create_logs_table extends Migration
+{
+    public const LOG_TABLE = '{{%feedme_logs}}';
+
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        if ($this->db->tableExists(self::LOG_TABLE)) {
+            return true;
+        }
+
+        // @see \craft\feedme\migrations\m240611_134740_create_logs_table
+        $this->createTable(self::LOG_TABLE, [
+            'id' => $this->bigPrimaryKey(),
+            'level' => $this->integer(),
+            'category' => $this->string(),
+            'log_time' => $this->double(),
+            'prefix' => $this->text(),
+            'message' => $this->text(),
+        ]);
+
+        $this->createIndex('idx_log_level', self::LOG_TABLE, 'level');
+        $this->createIndex('idx_log_category', self::LOG_TABLE, 'category');
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        if ($this->db->tableExists(self::LOG_TABLE)) {
+            $this->dropTable(self::LOG_TABLE);
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
### Description
- Converts the existing custom logging to a Yii Log Target with a `feed-me` category.
- By default, logs will now be stored in the database (`feedme_logs`), as they are displayed in the CP.

### Related issues
Fixes https://github.com/craftcms/feed-me/issues/1344
