### PR TITLE
do hash check before checking if both values are empty

### DIFF
--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -447,6 +447,7 @@ class DataHelper
 
         // check if both empty
         if (
+            Hash::check($fields, $key) &&
             (!is_numeric($firstValue) && !is_bool($firstValue) && empty($firstValue)) &&
             (!is_numeric($secondValue) && !is_bool($secondValue) && empty($secondValue))
         ) {


### PR DESCRIPTION
### Description
When comparing element content for simple values, we need to do a `Hash::check` first to ensure the field/attribute we’re about to do a comparison for exists in the first place.


### Related issues
#1469 
