### PR TITLE
Bugfix/1481 assets field filename dont import

### DIFF
--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -118,8 +118,10 @@ class Assets extends Field implements FieldInterface
         $base64ToUpload = [];
 
         $filenamesFromFeed = $upload ? DataHelper::fetchArrayValue($this->feedData, $this->fieldInfo, 'options.filenameNode') : null;
-        // see https://github.com/craftcms/feed-me/issues/1471
-        $filenamesFromFeed = array_splice($filenamesFromFeed, $nodeKey, count($value));
+        if ($filenamesFromFeed) {
+            // see https://github.com/craftcms/feed-me/issues/1471
+            $filenamesFromFeed = array_splice($filenamesFromFeed, $nodeKey, count($value));
+        }
 
         // Fire an 'onAssetFilename' event
         $event = new AssetFilenameEvent([

--- a/src/templates/_includes/fields/assets.html
+++ b/src/templates/_includes/fields/assets.html
@@ -75,7 +75,7 @@
                 label: 'Use this filename for assets created from URL:'|t('feed-me'),
                 name: 'options[filenameNode]',
                 value: hash_get(feed.fieldMapping, optionsPath ~ '.filenameNode') ?: '',
-                options: feedData,
+                options: feedData|filter(option => option.value != 'usedefault'),
                 class: 'selectize fullwidth',
             }) }}
         </div>


### PR DESCRIPTION
### Description
When importing into the Assets field and creating assets from URL, the “Use this filename for assets created from URL:” can be set to “don’t import” or be empty for some fields. In a case like this, we should proceed with the “original” filename and don’t throw an error.

Also, removed “Use default” as a dropdown option for “Use this filename for assets created from URL:”.


### Related issues
#1481 
