### PR TITLE
only return an empty string if setEmptyValues is set

### DIFF
--- a/src/fields/Dropdown.php
+++ b/src/fields/Dropdown.php
@@ -67,7 +67,7 @@ class Dropdown extends Field implements FieldInterface
             }
         }
 
-        if (empty($value)) {
+        if ($this->feed['setEmptyValues'] === 1 && $value === '') {
             return $value;
         }
 


### PR DESCRIPTION
### Description
When importing into a Dropdown field that doesn’t have an empty string as a valid option and the value provided in the feed is an empty string - only use it if `setEmptyValues` is set. Otherwise, treat the value as `null` and allow the field to handle the fallback.

This is less visible in v4 and Feed Me v5, but it can become a bit of a nuisance in v5 and Feed Me v6 when importing into a dropdown field inside a matrix field that’s set to the cards (or index) view.

### Related issues
[#15331](https://github.com/craftcms/cms/issues/15331)
