### PR TITLE
Don't log vars to DB

### DIFF
--- a/src/services/Logs.php
+++ b/src/services/Logs.php
@@ -80,6 +80,7 @@ class Logs extends Component
             'levels' => $this->getLogLevels(),
             'enabled' => $this->isEnabled(),
             'categories' => [self::LOG_CATEGORY],
+            'logVars' => [],
             'prefix' => static function(array $message) {
                 $log = Json::decodeIfJson($message[0]);
                 $feed = $log['feed'] ?? null;


### PR DESCRIPTION
### Description
When default logging was switched to use the DB, environment variables were inadvertently included by yii's DbTarget default behavior. Prior to this they weren't logged at all. Furthermore, they weren't redacted.

### Related issues
- https://github.com/craftcms/feed-me/issues/1491
