### PR TITLE
Bugfix/1499 inner element fields

### DIFF
--- a/src/web/twig/variables/FeedMeVariable.php
+++ b/src/web/twig/variables/FeedMeVariable.php
@@ -7,6 +7,7 @@ use craft\elements\User as UserElement;
 use craft\feedme\Plugin;
 use craft\fields\Checkboxes;
 use craft\fields\Color;
+use craft\fields\Country;
 use craft\fields\Date;
 use craft\fields\Dropdown;
 use craft\fields\Email;
@@ -229,7 +230,7 @@ class FeedMeVariable extends ServiceLocator
             $section = $this->getEntrySourcesByField($field)[0] ?? null;
 
             if ($section) {
-                $source = Craft::$app->getSections()->getEntryTypeById($section->id);
+                $source = $section->getEntryTypes()[0] ?? null;
             }
         } elseif ($type === 'craft\fields\Tags') {
             $source = $this->getTagSourcesByField($field);

--- a/src/web/twig/variables/FeedMeVariable.php
+++ b/src/web/twig/variables/FeedMeVariable.php
@@ -12,10 +12,12 @@ use craft\fields\Date;
 use craft\fields\Dropdown;
 use craft\fields\Email;
 use craft\fields\Lightswitch;
+use craft\fields\Money;
 use craft\fields\MultiSelect;
 use craft\fields\Number;
 use craft\fields\PlainText;
 use craft\fields\RadioButtons;
+use craft\fields\Time;
 use craft\fields\Url;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\Html;
@@ -344,13 +346,18 @@ class FeedMeVariable extends ServiceLocator
         $supportedSubFields = [
             Checkboxes::class,
             Color::class,
+            Country::class,
             Date::class,
             Dropdown::class,
+            Email::class,
             Lightswitch::class,
+            Money::class,
             MultiSelect::class,
             Number::class,
             PlainText::class,
             RadioButtons::class,
+            Time::class,
+            Url::class,
             'craft\ckeditor\Field',
             'craft\redactor\Field',
         ];


### PR DESCRIPTION
### Description
Fixes an issue where mapping inner fields for an entry field wasn't showing the correct fields.
It was initially fixed here: https://github.com/craftcms/feed-me/commit/5a75e50a376466dd243e299e15d6049823e1743c but then the pre-fix approach was used when updating to Craft 4 https://github.com/craftcms/feed-me/commit/66a2257ab67444874372e45e93cd32efa832f19f. 

Adds missing "simple" fields that can be used when mapping an element field.

@angrybrad, for Feed Me v6, the list under `src/web/twig/variables/FeedMeVariable.php::supportedSubField()` should also contain `Icon::class,` (where Icon is `craft\fields\Icon`). Let me know if you'd like me to raise a separate PR for v6 or if you're okay with adding that in when merging branches.


### Related issues
#1499 
