### PR TITLE
add support for custom sources

### DIFF
--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -12,7 +12,6 @@ use craft\feedme\base\FieldInterface;
 use craft\feedme\helpers\DataHelper;
 use craft\feedme\Plugin;
 use craft\fields\Categories as CategoriesField;
-use craft\helpers\ArrayHelper;
 use craft\helpers\Db;
 use craft\helpers\ElementHelper;
 use craft\helpers\Json;

--- a/src/fields/Users.php
+++ b/src/fields/Users.php
@@ -174,7 +174,7 @@ class Users extends Field implements FieldInterface
             // So if we haven't found a match with the previous query, and field sources contains "admins",
             // we have to look for the user among admins too.
             if ($isAdmin && count($ids) === 0) {
-                unset($criteria['groupId']);
+                $criteria['groupId'] = null;
                 $criteria['admin'] = true;
 
                 $ids = $this->_findUsers($criteria);

--- a/src/templates/_includes/fields/categories.html
+++ b/src/templates/_includes/fields/categories.html
@@ -62,12 +62,16 @@
         }) }}
     </div>
 
-    <div class="element-create">
-        {{ feedMeMacro.checkbox({
-            label: 'Create categories if they do not exist'|t('feed-me'),
-            name: 'options[create]',
-            value: 1,
-            checked: hash_get(feed.fieldMapping, optionsPath ~ '.create') ?: '',
-        }) }}
-    </div>
+    {# don't allow crating new categories if the source is custom, because we can't ensure all the conditions will be met;
+    e.g. level, date created or updated etc #}
+    {% if field is defined and field is not empty and field.source starts with 'custom:' == false %}
+        <div class="element-create">
+            {{ feedMeMacro.checkbox({
+                label: 'Create categories if they do not exist'|t('feed-me'),
+                name: 'options[create]',
+                value: 1,
+                checked: hash_get(feed.fieldMapping, optionsPath ~ '.create') ?: '',
+            }) }}
+        </div>
+    {% endif %}
 {% endblock %}

--- a/src/templates/_includes/fields/entries.html
+++ b/src/templates/_includes/fields/entries.html
@@ -65,7 +65,7 @@
     </div>
 
     {# don't allow crating new entries if the only selected source is custom, because we can't ensure all the conditions will be met #}
-    {% if field is defined and field is not empty and field.sources|length == 1 and field.sources.0 starts with 'custom:' == false %}
+    {% if field is defined and craft.feedme.fieldHasOnlyCustomSources(field) == false %}
         <div class="element-create">
             {{ feedMeMacro.checkbox({
                 label: 'Create entries if they do not exist'|t('feed-me'),

--- a/src/templates/_includes/fields/entries.html
+++ b/src/templates/_includes/fields/entries.html
@@ -64,14 +64,17 @@
         }) }}
     </div>
 
-    <div class="element-create">
-        {{ feedMeMacro.checkbox({
-            label: 'Create entries if they do not exist'|t('feed-me'),
-            name: 'options[create]',
-            value: 1,
-            checked: hash_get(feed.fieldMapping, optionsPath ~ '.create') ?: '',
-        }) }}
-    </div>
+    {# don't allow crating new entries if the only selected source is custom, because we can't ensure all the conditions will be met #}
+    {% if field is defined and field is not empty and field.sources|length == 1 and field.sources.0 starts with 'custom:' == false %}
+        <div class="element-create">
+            {{ feedMeMacro.checkbox({
+                label: 'Create entries if they do not exist'|t('feed-me'),
+                name: 'options[create]',
+                value: 1,
+                checked: hash_get(feed.fieldMapping, optionsPath ~ '.create') ?: '',
+            }) }}
+        </div>
+    {% endif %}
 
     {% if field %}
         <div class="element-groups">

--- a/src/templates/_includes/fields/users.html
+++ b/src/templates/_includes/fields/users.html
@@ -63,12 +63,15 @@
         }) }}
     </div>
 
-    <div class="element-create">
-        {{ feedMeMacro.checkbox({
-            label: 'Create users if they do not exist'|t('feed-me'),
-            name: 'options[create]',
-            value: 1,
-            checked: hash_get(feed.fieldMapping, optionsPath ~ '.create') ?: '',
-        }) }}
-    </div>
+    {# don't allow crating new entries if the only selected source is custom, because we can't ensure all the conditions will be met #}
+    {% if field is defined and field is not empty and field.sources|length == 1 and field.sources.0 starts with 'custom:' == false %}
+        <div class="element-create">
+            {{ feedMeMacro.checkbox({
+                label: 'Create users if they do not exist'|t('feed-me'),
+                name: 'options[create]',
+                value: 1,
+                checked: hash_get(feed.fieldMapping, optionsPath ~ '.create') ?: '',
+            }) }}
+        </div>
+    {% endif %}
 {% endblock %}

--- a/src/templates/_includes/fields/users.html
+++ b/src/templates/_includes/fields/users.html
@@ -64,7 +64,7 @@
     </div>
 
     {# don't allow crating new entries if the only selected source is custom, because we can't ensure all the conditions will be met #}
-    {% if field is defined and field is not empty and field.sources|length == 1 and field.sources.0 starts with 'custom:' == false %}
+    {% if field is defined and craft.feedme.fieldHasOnlyCustomSources(field) == false %}
         <div class="element-create">
             {{ feedMeMacro.checkbox({
                 label: 'Create users if they do not exist'|t('feed-me'),

--- a/src/web/twig/variables/FeedMeVariable.php
+++ b/src/web/twig/variables/FeedMeVariable.php
@@ -23,6 +23,7 @@ use craft\models\CategoryGroup;
 use craft\models\Section;
 use craft\models\TagGroup;
 use DateTime;
+use Illuminate\Support\Collection;
 use yii\di\ServiceLocator;
 
 /**
@@ -355,5 +356,27 @@ class FeedMeVariable extends ServiceLocator
         ];
 
         return in_array($class, $supportedSubFields, true);
+    }
+
+    /**
+     * Check if the only sources set for a relation field are custom ones.
+     *
+     * @param array|null $field
+     * @return bool
+     */
+    public function fieldHasOnlyCustomSources(?array $field = null): bool
+    {
+        if ($field === null) {
+            return false;
+        }
+
+        if (!isset($field['sources'])) {
+            return false;
+        }
+
+        $sources = new Collection($field['sources']);
+        $nativeSources = $sources->filter(fn(string $source) => !str_starts_with($source, 'custom:'));
+
+        return $nativeSources->isEmpty();
     }
 }

--- a/src/web/twig/variables/FeedMeVariable.php
+++ b/src/web/twig/variables/FeedMeVariable.php
@@ -361,10 +361,10 @@ class FeedMeVariable extends ServiceLocator
     /**
      * Check if the only sources set for a relation field are custom ones.
      *
-     * @param array|null $field
+     * @param mixed $field
      * @return bool
      */
-    public function fieldHasOnlyCustomSources(?array $field = null): bool
+    public function fieldHasOnlyCustomSources(mixed $field = null): bool
     {
         if ($field === null) {
             return false;


### PR DESCRIPTION
### Description
Adds support for importing into the relation fields that have custom source(s) selected.

- assets field => you can't select a custom source as the field's source
- categories field => the field can only have one source selected; it can be a custom source; in this PR I have:
	- disabled creating new categories if a custom source is selected (because of ensuring all the condition rules are met); this includes removal of the “Create categories if they do not exist” from the mapping screen;
	- made it possible to import existing categories into a categories field which has custom source selected
- entries field => the field can have multiple sources selected, including custom ones; in this PR I have:
	- made it possible to import entries into an entries field that has a custom source selected
	- disabled creating new entries if the only selected sources are custom ones (because of ensuring all the condition rules are met); this includes removal of the “Create entries if they do not exist” from the mapping screen;
- tags field => n/a; there is no area to create custom sources for tags
- users field => same as with entries


### Related issues
#1488 
