### PR TITLE
if we don't have extension, don't add a full stop to the filename

### DIFF
--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -181,7 +181,14 @@ class Assets extends Field implements FieldInterface
                     $urlsToUpload[$key]['value'] = $dataValue;
 
                     if (isset($filenamesFromFeed[$key])) {
-                        $filename = $filenamesFromFeed[$key] . '.' . AssetHelper::getRemoteUrlExtension($urlsToUpload[$key]['value']);
+                        $filename = $filenamesFromFeed[$key];
+
+                        // if we can determine the extension of the remote file, use that extension
+                        $remoteUrlExtension = AssetHelper::getRemoteUrlExtension($urlsToUpload[$key]['value']);
+                        if (!empty($remoteUrlExtension)) {
+                            $filename .= '.' . $remoteUrlExtension;
+                        }
+
                         $urlsToUpload[$key]['newFilename'] = $filename;
                     } else {
                         $filename = AssetHelper::getRemoteUrlFilename($dataValue);


### PR DESCRIPTION
### Description
When uploading files to an Assets field from an external URL and a new filename is provided (via “Use this filename for assets created from URL”), if we can’t get a remote file‘s extension, we shouldn’t append a full stop to the end of the filename.


### Related issues
#1489 
