### PR TITLE
when variant is new, set the product on it (that'll set ownership)

### DIFF
--- a/src/elements/CommerceProduct.php
+++ b/src/elements/CommerceProduct.php
@@ -448,6 +448,7 @@ class CommerceProduct extends Element
             // Create a new variant, or find an existing one to edit
             if (!isset($variants[$sku])) {
                 $variants[$sku] = new VariantElement();
+                $variants[$sku]->product = $element;
             }
 
             // We are going to handle stock after the product and variants save


### PR DESCRIPTION
### Description
When importing a new variant for a product, we need to set the product on the new variant element. That'll set the ownership and importing into custom fields will work again.


### Related issues
#1525 
