### PR TITLE
add option to download files for assets via guzzle

### DIFF
--- a/src/helpers/AssetHelper.php
+++ b/src/helpers/AssetHelper.php
@@ -53,10 +53,25 @@ class AssetHelper
             return fclose($fp);
         }
 
+        $fp = fopen($dstName, 'wb');
+
+        $assetDownloadGuzzle = Plugin::$plugin->service->getConfig('assetDownloadGuzzle', $feedId);
+        if ($assetDownloadGuzzle) {
+            $response = null;
+            $client = Plugin::$plugin->service->createGuzzleClient();
+            try {
+                $response = $client->get($srcName, ['sink' => $fp]);
+            } catch (Throwable $e) {
+            }
+
+            fclose($fp);
+
+            return $response?->getStatusCode() === 200;
+        }
+
         $newChunkSize = $chunkSize * (1024 * 1024);
         $bytesCount = 0;
         $handle = fopen($srcName, 'rb');
-        $fp = fopen($dstName, 'wb');
 
         if ($handle === false) {
             return false;

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -102,4 +102,10 @@ class Settings extends Model
      * @var bool
      */
     public bool $assetDownloadCurl = false;
+
+    /**
+     * @var bool
+     * @since 5.9.0
+     */
+    public bool $assetDownloadGuzzle = false;
 }


### PR DESCRIPTION
### Description
Added `assetDownloadGuzzle` setting. It’s `false` by default, but when set to `true`, the `AssetHelper::downloadFile()` method will download files using Guzzle, which means the `clientOptions` will apply to those downloads, too (if specified).

### Related issues
#1538 
