### PR TITLE
limit the search for categories by `groupId`

### DIFF
--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -152,6 +152,9 @@ class Categories extends Field implements FieldInterface
                 $columnName = Craft::$app->getFields()->oldFieldColumnPrefix . $match;
             }
 
+            if ($groupId) {
+                $criteria['groupId'] = $groupId;
+            }
             $criteria['status'] = null;
             $criteria['limit'] = $limit;
             $criteria['where'] = ['=', $columnName, $dataValue];


### PR DESCRIPTION
### Description
When searching for categories to add to the Categories field, and the source of the field is set to a group (not a custom source), use that group's id in the search query.


### Related issues
#1530 
