### PR TITLE
escape match value for the query

### DIFF
--- a/src/fields/CalendarEvents.php
+++ b/src/fields/CalendarEvents.php
@@ -8,6 +8,7 @@ use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
 use craft\feedme\helpers\DataHelper;
 use craft\feedme\Plugin;
+use craft\helpers\Db;
 use craft\helpers\Json;
 use Solspace\Calendar\Elements\Event as EventElement;
 
@@ -124,7 +125,7 @@ class CalendarEvents extends Field implements FieldInterface
             $criteria['status'] = null;
             $criteria['typeId'] = $typeIds;
             $criteria['limit'] = $limit;
-            $criteria[$match] = $dataValue;
+            $criteria[$match] = Db::escapeParam($dataValue);
 
             Craft::configure($query, $criteria);
 

--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -145,7 +145,7 @@ class Categories extends Field implements FieldInterface
 
             $criteria['status'] = null;
             $criteria['limit'] = $limit;
-            $criteria[$match] = $dataValue;
+            $criteria[$match] = Db::escapeParam($dataValue);
 
             Craft::configure($query, $criteria);
 

--- a/src/fields/CommerceProducts.php
+++ b/src/fields/CommerceProducts.php
@@ -129,7 +129,7 @@ class CommerceProducts extends Field implements FieldInterface
             $criteria['status'] = null;
             $criteria['typeId'] = $typeIds;
             $criteria['limit'] = $limit;
-            $criteria[$match] = $dataValue;
+            $criteria[$match] = Db::escapeParam($dataValue);
 
             Craft::configure($query, $criteria);
 

--- a/src/fields/CommerceVariants.php
+++ b/src/fields/CommerceVariants.php
@@ -10,6 +10,7 @@ use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
 use craft\feedme\helpers\DataHelper;
 use craft\feedme\Plugin;
+use craft\helpers\Db;
 use craft\helpers\Json;
 
 /**
@@ -128,7 +129,7 @@ class CommerceVariants extends Field implements FieldInterface
             $criteria['status'] = null;
             $criteria['typeId'] = $typeIds;
             $criteria['limit'] = $limit;
-            $criteria[$match] = $dataValue;
+            $criteria[$match] = Db::escapeParam($dataValue);
 
             Craft::configure($query, $criteria);
 

--- a/src/fields/DigitalProducts.php
+++ b/src/fields/DigitalProducts.php
@@ -9,6 +9,7 @@ use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
 use craft\feedme\helpers\DataHelper;
 use craft\feedme\Plugin;
+use craft\helpers\Db;
 use craft\helpers\Json;
 
 /**
@@ -129,7 +130,7 @@ class DigitalProducts extends Field implements FieldInterface
             $criteria['status'] = null;
             $criteria['typeId'] = $typeIds;
             $criteria['limit'] = $limit;
-            $criteria[$match] = $dataValue;
+            $criteria[$match] = Db::escapeParam($dataValue);
 
             Craft::configure($query, $criteria);
 

--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -164,7 +164,7 @@ class Entries extends Field implements FieldInterface
 
             $criteria['status'] = null;
             $criteria['limit'] = $limit;
-            $criteria[$match] = $dataValue;
+            $criteria[$match] = Db::escapeParam($dataValue);
 
             Craft::configure($query, $criteria);
 

--- a/src/fields/Tags.php
+++ b/src/fields/Tags.php
@@ -127,7 +127,7 @@ class Tags extends Field implements FieldInterface
             $criteria['status'] = null;
             $criteria['groupId'] = $groupId;
             $criteria['limit'] = $limit;
-            $criteria[$match] = $dataValue;
+            $criteria[$match] = Db::escapeParam($dataValue);
 
             Craft::configure($query, $criteria);
 

--- a/src/fields/Users.php
+++ b/src/fields/Users.php
@@ -152,7 +152,7 @@ class Users extends Field implements FieldInterface
             $ids = [];
             $criteria['status'] = null;
             $criteria['limit'] = $limit;
-            $criteria[$match] = $dataValue;
+            $criteria[$match] = Db::escapeParam($dataValue);
 
             // If the only source for the Users field is "admins" we don't have to bother with this query.
             if (!($isAdmin && empty($groupIds) && empty($customSources))) {


### PR DESCRIPTION
### Description
When searching for matching existing elements, escape the value used for matching.

Note: this is not an issue in v5 (for Craft 4), as in v5, the matching is done slightly differently.


### Related issues
#1542 
