### PR TITLE
Add support for importing Time fields

### DIFF
--- a/src/fields/Time.php
+++ b/src/fields/Time.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace craft\feedme\fields;
+
+use craft\feedme\base\Field;
+use craft\feedme\base\FieldInterface;
+use craft\feedme\helpers\DateHelper;
+use craft\fields\Time as TimeField;
+
+/**
+ *
+ * @property-read string $mappingTemplate
+ */
+class Time extends Field implements FieldInterface
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var string
+     */
+    public static string $name = 'Time';
+
+    /**
+     * @var string
+     */
+    public static string $class = TimeField::class;
+
+    // Templates
+    // =========================================================================
+
+    /**
+     * @inheritDoc
+     */
+    public function getMappingTemplate(): string
+    {
+        return 'feed-me/_includes/fields/time';
+    }
+
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * @inheritDoc
+     */
+    public function parseField(): mixed
+    {
+        $value = $this->fetchValue();
+
+        if ($value === null) {
+            return null;
+        }
+
+        $timeValue = DateHelper::parseTimeString($value);
+
+        if ($timeValue) {
+            return $timeValue;
+        }
+
+        return $value;
+    }
+}

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -38,6 +38,7 @@ use craft\feedme\fields\SmartMap;
 use craft\feedme\fields\SuperTable;
 use craft\feedme\fields\Table;
 use craft\feedme\fields\Tags;
+use craft\feedme\fields\Time;
 use craft\feedme\fields\TypedLink;
 use craft\feedme\fields\Users;
 use craft\helpers\Component as ComponentHelper;
@@ -142,6 +143,7 @@ class Fields extends Component
                 RadioButtons::class,
                 Table::class,
                 Tags::class,
+                Time::class,
                 Users::class,
 
                 // Third-Party

--- a/src/templates/_includes/fields/time.html
+++ b/src/templates/_includes/fields/time.html
@@ -1,0 +1,8 @@
+{% import 'feed-me/_macros' as feedMeMacro %}
+{% import '_includes/forms' as forms %}
+
+{% set default = default ?? {
+    type: 'time',
+} %}
+
+{% extends 'feed-me/_includes/fields/_base' %}


### PR DESCRIPTION
### Description

This adds initial support for Feed Me to properly handle Craft time fields. Currently time fields are only possible to be imported when times are written as strings. This update parses time values through the DateHelper to ensure they are valid. Using the existing DateHelper, the parseTimeString method is used to parse mapped values.

In addition, the default value on the mapping uses a Craft time field, rather than a plain text field

The following test data was used as part of testing:

```json
{
  "content": [{
    "title": "Example entry title 1",
    "startTime": "13:00",
    "endTime": "15:00"
  }, {
    "title": "Example entry title 2",
    "startTime": "01-01-1900 16:00",
    "endTime": "01-01-1900 18:00"
  }]
}
```

This is the initial starting point to ensure time fields can be used in Feed Me, currently there is no proper handling of this field type leading to issues with importing.

### Related issues

#1561 