### PR TITLE
Settings pages are only for admins and when `allowAdminChanges` is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Feed Me
 
+## Unreleased
+
+- Feed Me settings are now only available when `allowAdminChanges` are set to `true`. ([#1581](https://github.com/craftcms/feed-me/pull/1581))
+
 ## 5.9.0 - 2024-11-26
 
 - Added the `assetDownloadGuzzle` config setting which defaults to `false`. When it is set to `true`, Feed Me will use Guzzle to download assets instead curl directly. ([#1549](https://github.com/craftcms/feed-me/pull/1549))

--- a/docs/.vitepress/utils.js
+++ b/docs/.vitepress/utils.js
@@ -7,7 +7,7 @@ function renderInlineCode(tokens, idx, options, env, renderer) {
   var token = tokens[idx];
 
   return `<code v-pre ${renderer.renderAttrs(token)}>${escapeHtml(
-    tokens[idx].content,
+    tokens[idx].content
   )}</code>`;
 }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -155,6 +155,7 @@ class Plugin extends \craft\base\Plugin
                 'feed-me/feeds/run/<feedId:\d+>' => 'feed-me/feeds/run-feed',
                 'feed-me/feeds/status/<feedId:\d+>' => 'feed-me/feeds/status-feed',
                 'feed-me/logs' => 'feed-me/logs/logs',
+                'feed-me/utilities' => ['template' => 'feed-me/utilities/index'],
                 'feed-me/settings/general' => 'feed-me/base/settings',
             ]);
         });

--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -23,6 +23,8 @@ class BaseController extends Controller
      */
     public function actionSettings(): Response
     {
+        $this->requireAdmin();
+
         $settings = Plugin::$plugin->getSettings();
 
         return $this->renderTemplate('feed-me/settings/general', [

--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -43,6 +43,6 @@ class BaseController extends Controller
             ->delete('{{%queue}}')
             ->execute();
 
-        return $this->redirect('feed-me/settings/general');
+        return $this->redirect('feed-me/utilities');
     }
 }

--- a/src/templates/settings/general.html
+++ b/src/templates/settings/general.html
@@ -1,3 +1,5 @@
+{% requireAdmin %}
+
 {% extends 'feed-me/_layouts/settings' %}
 
 {% import '_includes/forms' as forms %}

--- a/src/templates/settings/general.html
+++ b/src/templates/settings/general.html
@@ -40,17 +40,12 @@
         options: {
             'feeds': 'Feeds'|t('feed-me'),
             'logs': 'Logs'|t('feed-me'),
+            'utilities': 'Utilities'|t('feed-me'),
             'settings': 'Settings'|t('feed-me'),
         },
         values: settings.enabledTabs,
         instructions: 'Choose which tabs you would like to be shown.'|t('feed-me'),
     }) }}
-
-    <hr>
-
-    <a class="btn" href="{{ actionUrl('feed-me/base/clear-tasks') }}">
-        {{ "Clear pending job queue"|t('feed-me') }}
-    </a>
 
     {% endnamespace %}
 

--- a/src/templates/utilities/index.html
+++ b/src/templates/utilities/index.html
@@ -1,0 +1,14 @@
+{% extends 'feed-me/_layouts' %}
+
+{% set crumbs = [
+    { label: craft.feedme.getPluginName|t('feed-me'), url: url('feed-me') },
+    { label: "Utilities"|t('feed-me'), url: url('feed-me/utilities') }
+] %}
+
+{% set selectedTab = 'utilities' %}
+
+{% block content %}
+    <a class="btn" href="{{ actionUrl('feed-me/base/clear-tasks') }}">
+        {{ "Clear pending job queue"|t('feed-me') }}
+    </a>
+{% endblock %}

--- a/src/web/twig/variables/FeedMeVariable.php
+++ b/src/web/twig/variables/FeedMeVariable.php
@@ -58,6 +58,7 @@ class FeedMeVariable extends ServiceLocator
         $tabs = [
             'feeds' => ['label' => Craft::t('feed-me', 'Feeds'), 'url' => UrlHelper::cpUrl('feed-me/feeds')],
             'logs' => ['label' => Craft::t('feed-me', 'Logs'), 'url' => UrlHelper::cpUrl('feed-me/logs')],
+            'utilities' => ['label' => Craft::t('feed-me', 'Utilities'), 'url' => UrlHelper::cpUrl('feed-me/utilities')],
         ];
 
         if (Craft::$app->getUser()->getIsAdmin() && Craft::$app->getConfig()->getGeneral()->allowAdminChanges) {

--- a/src/web/twig/variables/FeedMeVariable.php
+++ b/src/web/twig/variables/FeedMeVariable.php
@@ -58,8 +58,11 @@ class FeedMeVariable extends ServiceLocator
         $tabs = [
             'feeds' => ['label' => Craft::t('feed-me', 'Feeds'), 'url' => UrlHelper::cpUrl('feed-me/feeds')],
             'logs' => ['label' => Craft::t('feed-me', 'Logs'), 'url' => UrlHelper::cpUrl('feed-me/logs')],
-            'settings' => ['label' => Craft::t('feed-me', 'Settings'), 'url' => UrlHelper::cpUrl('feed-me/settings')],
         ];
+
+        if (Craft::$app->getUser()->getIsAdmin() && Craft::$app->getConfig()->getGeneral()->allowAdminChanges) {
+            $tabs['settings'] = ['label' => Craft::t('feed-me', 'Settings'), 'url' => UrlHelper::cpUrl('feed-me/settings')];
+        }
 
         if (!is_array($enabledTabs)) {
             return $tabs;


### PR DESCRIPTION
### Description
The settings page should only be available to admins and only when `allowAdminChanges` is `true`.

The “Clear pending job queue” button, which was located on the Settings -> General page, was never restricted to just being available to admins, so I moved it to a new “Utilities” tab. This way, you’ll still be able to access it and trigger the action as you were before, even if you’re not an admin or the `allowAdminChanges` is off.

Note: if the plugin is not set up to show all the tabs, you might need/want to select the new “Utilities” tab and deploy the project config changes.


### Related issues
n/a
