### PR TITLE
Allow Modification of Feed Attributes in EVENT_BEFORE_PROCESS_FEED

### DIFF
--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -146,9 +146,8 @@ class Process extends Component
 
         // Fire an 'onBeforeProcessFeed' event
         $event = new FeedProcessEvent([
-            'feed' => $return,
+            'feed' => $feed,
             'feedData' => $this->_data,
-            'element' => $feed->element,
         ]);
 
         $this->trigger(self::EVENT_BEFORE_PROCESS_FEED, $event);
@@ -157,8 +156,7 @@ class Process extends Component
             return;
         }
 
-        // Allow event to modify the feed & feed data
-        $return = $event->feed;
+        // Allow event to modify the feed data
         $this->_data = $event->feedData;
 
         // Return the feed data

--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -146,8 +146,9 @@ class Process extends Component
 
         // Fire an 'onBeforeProcessFeed' event
         $event = new FeedProcessEvent([
-            'feed' => $feed,
+            'feed' => $return,
             'feedData' => $this->_data,
+            'element' => $feed->element,
         ]);
 
         $this->trigger(self::EVENT_BEFORE_PROCESS_FEED, $event);
@@ -156,7 +157,8 @@ class Process extends Component
             return;
         }
 
-        // Allow event to modify the feed data
+        // Allow event to modify the feed & feed data
+        $return = $event->feed;
         $this->_data = $event->feedData;
 
         // Return the feed data


### PR DESCRIPTION
### Description
Currently, it's not possible to modify the feed attributes in the `beforeProcessFeed` function. While there is an event triggered `EVENT_BEFORE_PROCESS_FEED`, it doesn't allow editing of the feed attributes. For my use case, I need the ability to change the `existingElements` that are later deleted or disabled.

To address this, I’ve introduced a breaking change: the feed now returns an array instead of a `FeedModel`. This aligns with the pattern used by other events, which also return an array of feed attributes. Additionally, I've added an element key to simplify access to the feed element type you're currently working with.

Please let me know if any adjustments are needed, and I’d appreciate any feedback to help get this merged.

### Related issues

#1577 