### PR TITLE
Feature/1572 relation field elements matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Feed Me
 
+## Unreleased
+
+- Improved the experience of mapping relational fields with individual field instances in Craft 5. ([#1585](https://github.com/craftcms/feed-me/issues/1585))
+
 ## 6.6.1 - 2024-12-01
 
 - Fixed a PHP error that could occur if you did not have Commerce installed when running a feed. ([#1556](https://github.com/craftcms/feed-me/issues/1556)) 

--- a/docs/.vitepress/utils.js
+++ b/docs/.vitepress/utils.js
@@ -7,7 +7,7 @@ function renderInlineCode(tokens, idx, options, env, renderer) {
   var token = tokens[idx];
 
   return `<code v-pre ${renderer.renderAttrs(token)}>${escapeHtml(
-    tokens[idx].content,
+    tokens[idx].content
   )}</code>`;
 }
 

--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -5,12 +5,16 @@ namespace craft\feedme\fields;
 use Cake\Utility\Hash;
 use Craft;
 use craft\base\Element as BaseElement;
+use craft\elements\Category;
 use craft\elements\Category as CategoryElement;
 use craft\elements\conditions\ElementConditionInterface;
 use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
 use craft\feedme\helpers\DataHelper;
+use craft\feedme\helpers\FieldHelper;
+use craft\feedme\models\FeedModel;
 use craft\feedme\Plugin;
+use craft\fields\BaseRelationField;
 use craft\fields\Categories as CategoriesField;
 use craft\helpers\Db;
 use craft\helpers\ElementHelper;
@@ -213,6 +217,46 @@ class Categories extends Field implements FieldInterface
         }
 
         return $foundElements;
+    }
+
+    /**
+     * Returns an array of custom fields that can be used when querying for matching categories.
+     *
+     * If a field is passed, use the field layout linked to the source (category group) selected in the Categories field's settings.
+     * If the source is native (it's a category group), only return the custom fields from its layout.
+     * If the source is custom, return all the fields in the installation.
+     *
+     * @param FeedModel $feed
+     * @param BaseRelationField|null $field
+     * @return array
+     */
+    public static function getMatchFields(FeedModel $feed, ?BaseRelationField $field = null): array
+    {
+        // The field will be null e.g. when importing into a categories group with maintain hierarchy turned on;
+        // in that case, there's the option to select a parent;
+        // the parent is serviced by the categories field markup too, but it doesn't tie into a custom field per se;
+        if ($field === null) {
+            $categoryGroup = Craft::$app->getCategories()->getGroupById($feed->elementGroup[Category::class]);
+            if (!$categoryGroup) {
+                return FieldHelper::getAllUniqueIdFields();
+            }
+            $fieldLayout = Craft::$app->getFields()->getLayoutById($categoryGroup->fieldLayoutId);
+            if (!$fieldLayout) {
+                return FieldHelper::getAllUniqueIdFields();
+            }
+
+            return array_filter($fieldLayout->getCustomFields(), fn($field) => FieldHelper::fieldCanBeUniqueId($field));
+        } else {
+            // if the Categories field has only custom source - we have no choice but return all the field
+            if (FieldHelper::fieldHasOnlyCustomSources($field)) {
+                return FieldHelper::getAllUniqueIdFields();
+            }
+            // otherwise get the layout for the group selected in the field's settings
+            return array_filter(
+                FieldHelper::getElementLayoutByField($field::class, $field),
+                fn($field) => FieldHelper::fieldCanBeUniqueId($field)
+            );
+        }
     }
 
     // Private Methods

--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -6,17 +6,22 @@ use Cake\Utility\Hash;
 use Craft;
 use craft\base\Element as BaseElement;
 use craft\elements\conditions\ElementConditionInterface;
+use craft\elements\Entry;
 use craft\elements\Entry as EntryElement;
 use craft\errors\ElementNotFoundException;
 use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
 use craft\feedme\helpers\DataHelper;
+use craft\feedme\helpers\FieldHelper;
+use craft\feedme\models\FeedModel;
 use craft\feedme\Plugin;
+use craft\fields\BaseRelationField;
 use craft\fields\Entries as EntriesField;
 use craft\helpers\Db;
 use craft\helpers\ElementHelper;
 use craft\helpers\Json;
 use craft\services\ElementSources;
+use Illuminate\Support\Collection;
 use Throwable;
 use yii\base\Exception;
 
@@ -238,6 +243,69 @@ class Entries extends Field implements FieldInterface
         }
 
         return $foundElements;
+    }
+
+    /**
+     * Returns an array of custom fields that can be used when querying for matching entries.
+     *
+     * If a field is passed, use the field layouts linked to the sources allowed by the Entries field.
+     * If all the sources are native (sections), then only fields from all those sections entry types field layouts will be returned.
+     * If there's at least one custom source in the mix, the above list will be followed by a list of all the fields.
+     * If only custom sources are selected, return all the fields in the installation.
+     *
+     * @param FeedModel $feed
+     * @param BaseRelationField|null $field
+     * @return array
+     */
+    public static function getMatchFields(FeedModel $feed, ?BaseRelationField $field = null): array
+    {
+        // The field will be null e.g. when importing into a structure section and there's the option to select a parent
+        // the parent is serviced by the entries field markup too, but it doesn't tie into a custom field per se;
+        if ($field === null) {
+            $entryType = Craft::$app->getEntries()->getEntryTypeById($feed->elementGroup[Entry::class]['entryType']);
+            if (!$entryType) {
+                return FieldHelper::getAllUniqueIdFields();
+            }
+
+            $fieldLayout = Craft::$app->getFields()->getLayoutById($entryType->fieldLayoutId);
+            if (!$fieldLayout) {
+                return FieldHelper::getAllUniqueIdFields();
+            }
+
+            return array_filter(
+                $fieldLayout->getCustomFields(),
+                fn($field) => FieldHelper::fieldCanBeUniqueId($field)
+            );
+        } else {
+            // if the Entries field has only custom sources - we have no choice but return all the field
+            if (FieldHelper::fieldHasOnlyCustomSources($field)) {
+                return FieldHelper::getAllUniqueIdFields();
+            }
+
+            // deal with the native sources - sections
+            $sections = FieldHelper::getEntrySourcesByField($field);
+            $entryTypes = [];
+            foreach ($sections as $section) {
+                $entryTypes = [...$entryTypes, ...$section->getEntryTypes()];
+            }
+
+            $allowedFields = [];
+            $entryTypes = Collection::make($entryTypes)->keyBy('id');
+
+            foreach ($entryTypes as $entryType) {
+                $fieldLayout = Craft::$app->getFields()->getLayoutById($entryType->fieldLayoutId);
+                $allowedFields = [...$allowedFields, ...$fieldLayout->getCustomFields()];
+            }
+
+            // if there's a custom source in the mix, we should add all the fields too
+            $customSources = array_filter($field['sources'], (fn(string $source) => str_starts_with($source, 'custom:')));
+
+            if (!empty($customSources)) {
+                $allowedFields = [...$allowedFields, ...Craft::$app->getFields()->getAllFields()];
+            }
+
+            return array_filter($allowedFields, fn($field) => FieldHelper::fieldCanBeUniqueId($field));
+        }
     }
 
 

--- a/src/fields/Users.php
+++ b/src/fields/Users.php
@@ -12,7 +12,10 @@ use craft\errors\ElementNotFoundException;
 use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
 use craft\feedme\helpers\DataHelper;
+use craft\feedme\helpers\FieldHelper;
+use craft\feedme\models\FeedModel;
 use craft\feedme\Plugin;
+use craft\fields\BaseRelationField;
 use craft\fields\Users as UsersField;
 use craft\helpers\Db;
 use craft\helpers\ElementHelper;
@@ -207,6 +210,19 @@ class Users extends Field implements FieldInterface
         }
 
         return $foundElements;
+    }
+
+    /**
+     * Returns an array of custom fields that can be used when querying for matching users.
+     * There's only one user layout, so the fields from it are returned.
+     *
+     * @param FeedModel $feed
+     * @param BaseRelationField|null $field
+     * @return array
+     */
+    public static function getMatchFields(FeedModel $feed, ?BaseRelationField $field = null): array
+    {
+        return array_filter(FieldHelper::getUserLayoutByField(), fn ($field) => FieldHelper::fieldCanBeUniqueId($field));
     }
 
     // Private Methods

--- a/src/fields/Users.php
+++ b/src/fields/Users.php
@@ -222,7 +222,7 @@ class Users extends Field implements FieldInterface
      */
     public static function getMatchFields(FeedModel $feed, ?BaseRelationField $field = null): array
     {
-        return array_filter(FieldHelper::getUserLayoutByField(), fn ($field) => FieldHelper::fieldCanBeUniqueId($field));
+        return array_filter(FieldHelper::getUserLayoutByField(), fn($field) => FieldHelper::fieldCanBeUniqueId($field));
     }
 
     // Private Methods

--- a/src/helpers/FieldHelper.php
+++ b/src/helpers/FieldHelper.php
@@ -276,7 +276,7 @@ class FieldHelper
     {
         return array_filter(
             Craft::$app->getFields()->getAllFields(),
-            fn($field) => $this->fieldCanBeUniqueId($field)
+            fn($field) => static::fieldCanBeUniqueId($field)
         );
     }
 }

--- a/src/helpers/FieldHelper.php
+++ b/src/helpers/FieldHelper.php
@@ -185,6 +185,12 @@ class FieldHelper
         return $return;
     }
 
+    /**
+     * Returns if the field can be used as a unique identifier.
+     *
+     * @param $field
+     * @return bool
+     */
     public static function fieldCanBeUniqueId($field): bool
     {
         $type = $field['type'] ?? 'attribute';
@@ -261,6 +267,11 @@ class FieldHelper
         return $nativeSources->isEmpty();
     }
 
+    /**
+     * Returns an array of all the custom fields that can be used as a unique id.
+     *
+     * @return array
+     */
     public static function getAllUniqueIdFields(): array
     {
         return array_filter(

--- a/src/helpers/FieldHelper.php
+++ b/src/helpers/FieldHelper.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace craft\feedme\helpers;
+
+use Craft;
+use craft\elements\User as UserElement;
+use craft\fields\Checkboxes;
+use craft\fields\Color;
+use craft\fields\Date;
+use craft\fields\Dropdown;
+use craft\fields\Email;
+use craft\fields\Lightswitch;
+use craft\fields\MultiSelect;
+use craft\fields\Number;
+use craft\fields\PlainText;
+use craft\fields\RadioButtons;
+use craft\fields\Url;
+use craft\models\CategoryGroup;
+use craft\models\Section;
+use craft\models\TagGroup;
+use Illuminate\Support\Collection;
+
+class FieldHelper
+{
+    // Public Methods
+    // =========================================================================
+
+    //
+    // Helper functions for element fields to get their first source. This is tricky as some elements
+    // support multiple sources (Entries, Users), whilst others can only have one (Tags, Categories)
+    //
+
+    public static function getAssetSourcesByField($field): ?array
+    {
+        $sources = [];
+
+        if (!$field) {
+            return null;
+        }
+
+        if (is_array($field->sources)) {
+            foreach ($field->sources as $source) {
+                [, $uid] = explode(':', $source);
+
+                $sources[] = Craft::$app->volumes->getVolumeByUid($uid);
+            }
+        } elseif ($field->sources === '*') {
+            $sources = Craft::$app->volumes->getAllVolumes();
+        }
+
+        return $sources;
+    }
+
+    public static function getCategorySourcesByField($field): ?CategoryGroup
+    {
+        if (!$field) {
+            return null;
+        }
+
+        [, $uid] = explode(':', $field->source);
+
+        return Craft::$app->categories->getGroupByUid($uid);
+    }
+
+    public static function getEntrySourcesByField($field): ?array
+    {
+        $sources = [];
+
+        if (!$field) {
+            return null;
+        }
+
+        if (is_array($field->sources)) {
+            foreach ($field->sources as $source) {
+                if ($source == 'singles') {
+                    foreach (Craft::$app->getEntries()->getAllSections() as $section) {
+                        if ($section->type == 'single') {
+                            $sources[] = $section;
+                        }
+                    }
+                } else {
+                    [, $uid] = explode(':', $source);
+
+                    $section = Craft::$app->getEntries()->getSectionByUid($uid);
+                    // only add to sources, if this was a section that we were able to retrieve (native section's uid)
+                    // https://github.com/craftcms/feed-me/issues/1186
+                    if ($section) {
+                        $sources[] = $section;
+                    }
+                }
+            }
+        } elseif ($field->sources === '*') {
+            $sources = Craft::$app->getEntries()->getAllSections();
+        }
+
+        return $sources;
+    }
+
+    public static function getTagSourcesByField($field): ?TagGroup
+    {
+        if (!$field) {
+            return null;
+        }
+
+        [, $uid] = explode(':', $field->source);
+
+        return Craft::$app->tags->getTagGroupByUid($uid);
+    }
+
+    //
+    // Helper functions for element fields in getting their inner-element field layouts
+    //
+
+    public static function getElementLayoutByField($type, $field): ?array
+    {
+        $source = null;
+
+        if ($type === 'craft\fields\Assets') {
+            $source = static::getAssetSourcesByField($field)[0] ?? null;
+        } elseif ($type === 'craft\fields\Categories') {
+            $source = static::getCategorySourcesByField($field);
+        } elseif ($type === 'craft\fields\Entries') {
+            /** @var Section $section */
+            $section = static::getEntrySourcesByField($field)[0] ?? null;
+
+            if ($section) {
+                $source = $section->getEntryTypes()[0] ?? null;
+            }
+        } elseif ($type === 'craft\fields\Tags') {
+            $source = static::getTagSourcesByField($field);
+        }
+
+        if (!$source || !$source->fieldLayoutId) {
+            return null;
+        }
+
+        if (($fieldLayout = Craft::$app->getFields()->getLayoutById($source->fieldLayoutId)) !== null) {
+            return $fieldLayout->getCustomFields();
+        }
+
+        return null;
+    }
+
+    public static function getUserLayoutByField(): ?array
+    {
+        $layoutId = Craft::$app->getFields()->getLayoutByType(UserElement::class)->id;
+
+        if (!$layoutId) {
+            return null;
+        }
+
+        if (($fieldLayout = Craft::$app->getFields()->getLayoutById($layoutId)) !== null) {
+            return $fieldLayout->getCustomFields();
+        }
+
+        return null;
+    }
+
+    public static function getAssetFolderBySourceId($id): array
+    {
+        $folders = Craft::$app->getAssets()->getFolderTreeByVolumeIds([$id]);
+
+        $return = [];
+
+        $return[''] = Craft::t('feed-me', 'Don\'t Import');
+
+        foreach ($folders as $folder) {
+            $return[] = [
+                'value' => 'root',
+                'label' => Craft::t('feed-me', 'Root Folder'),
+            ];
+
+            $children = $folder->getChildren();
+
+            if ($children) {
+                foreach ($children as $childFolder) {
+                    $return[] = [
+                        'value' => $childFolder['id'],
+                        'label' => $childFolder['name'],
+                    ];
+                }
+            }
+        }
+
+        return $return;
+    }
+
+    public static function fieldCanBeUniqueId($field): bool
+    {
+        $type = $field['type'] ?? 'attribute';
+
+        if (isset($field['type']) && $field['handle'] === 'parent') {
+            $type = 'parent';
+        }
+
+        if (is_object($field)) {
+            $type = get_class($field);
+        }
+
+        $supportedFields = [
+            Checkboxes::class,
+            Color::class,
+            Date::class,
+            Dropdown::class,
+            Email::class,
+            Lightswitch::class,
+            MultiSelect::class,
+            Number::class,
+            PlainText::class,
+            RadioButtons::class,
+            Url::class,
+        ];
+
+        $supportedValues = [
+            'assets',
+            'attribute',
+            'parent',
+        ];
+
+        $supported = array_merge($supportedFields, $supportedValues);
+
+        if (in_array($type, $supported, true)) {
+            return true;
+        }
+
+        // Include any field types that extend one of the above
+        foreach ($supportedFields as $supportedField) {
+            if (is_a($type, $supportedField, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if the only sources set for a relation field are custom ones.
+     *
+     * @param mixed $field
+     * @return bool
+     */
+    public static function fieldHasOnlyCustomSources(mixed $field = null): bool
+    {
+        if ($field === null) {
+            return false;
+        }
+
+        if (!isset($field['sources']) && !isset($field['source'])) {
+            return false;
+        }
+
+        if (empty($field['source'])) {
+            $fieldSources = $field['sources'];
+        } else {
+            $fieldSources = $field['source'];
+        }
+
+        $sources = new Collection($fieldSources);
+        $nativeSources = $sources->filter(fn(string $source) => !str_starts_with($source, 'custom:'));
+
+        return $nativeSources->isEmpty();
+    }
+
+    public static function getAllUniqueIdFields(): array
+    {
+        return array_filter(
+            Craft::$app->getFields()->getAllFields(),
+            fn($field) => $this->fieldCanBeUniqueId($field)
+        );
+    }
+}

--- a/src/templates/_includes/fields/categories.html
+++ b/src/templates/_includes/fields/categories.html
@@ -46,11 +46,11 @@
             { value: 'slug', label: 'Slug'|t('feed-me') },
         ] %}
 
-        {% for field in craft.app.fields.getAllFields() %}
-            {% if craft.feedme.fieldCanBeUniqueId(field) %}
-                {% set matchAttributes = matchAttributes|merge({ (field.handle): field.name }) %}
-            {% endif %}
-        {% endfor %}
+        {% if field is defined and field is not empty %}
+            {% set matchAttributes = matchAttributes|merge(craft.feedme.getRelationFieldMatchOptions(className(field), feed, field)) %}
+        {% else %}
+            {% set matchAttributes = matchAttributes|merge(craft.feedme.getRelationFieldMatchOptions('craft\\fields\\Categories', feed, null)) %}
+        {% endif %}
 
         {{ forms.selectField({
             name: 'options[match]',

--- a/src/templates/_includes/fields/entries.html
+++ b/src/templates/_includes/fields/entries.html
@@ -48,11 +48,11 @@
             { value: 'slug', label: 'Slug'|t('feed-me') },
         ] %}
 
-        {% for field in craft.app.fields.getAllFields() %}
-            {% if craft.feedme.fieldCanBeUniqueId(field) %}
-                {% set matchAttributes = matchAttributes|merge({ (field.handle): field.name }) %}
-            {% endif %}
-        {% endfor %}
+        {% if field is defined and field is not empty %}
+            {% set matchAttributes = matchAttributes|merge(craft.feedme.getRelationFieldMatchOptions(className(field), feed, field)) %}
+        {% else %}
+            {% set matchAttributes = matchAttributes|merge(craft.feedme.getRelationFieldMatchOptions('craft\\fields\\Entries', feed, null)) %}
+        {% endif %}
 
         {{ forms.selectField({
             name: 'options[match]',

--- a/src/templates/_includes/fields/users.html
+++ b/src/templates/_includes/fields/users.html
@@ -47,11 +47,11 @@
             { value: 'fullName', label: 'Full Name'|t('feed-me') },
         ] %}
 
-        {% for field in craft.app.fields.getAllFields() %}
-            {% if craft.feedme.fieldCanBeUniqueId(field) %}
-                {% set matchAttributes = matchAttributes|merge({ (field.handle): field.name }) %}
-            {% endif %}
-        {% endfor %}
+        {% if field is defined and field is not empty %}
+            {% set matchAttributes = matchAttributes|merge(craft.feedme.getRelationFieldMatchOptions(className(field), feed, field)) %}
+        {% else %}
+            {% set matchAttributes = matchAttributes|merge(craft.feedme.getRelationFieldMatchOptions('craft\\fields\\Users', feed, null)) %}
+        {% endif %}
 
         {{ forms.selectField({
             name: 'options[match]',

--- a/src/web/assets/feedme/src/js/feed-me.js
+++ b/src/web/assets/feedme/src/js/feed-me.js
@@ -23,7 +23,7 @@ $(function () {
 
   // Change the import strategy for Users
   var $disableLabel = $(
-    'input[name="duplicateHandle[]"][value="disable"]',
+    'input[name="duplicateHandle[]"][value="disable"]'
   ).next('label');
   var originalDisableLabel = $disableLabel.text();
   var $disableInstructions = $disableLabel.siblings('.instructions');
@@ -39,10 +39,7 @@ $(function () {
     if (value === 'craft-elements-User') {
       $disableLabel.text(Craft.t('feed-me', 'Suspend missing users'));
       $disableInstructions.text(
-        Craft.t(
-          'feed-me',
-          'Suspends any users that are missing from the feed.',
-        ),
+        Craft.t('feed-me', 'Suspends any users that are missing from the feed.')
       );
     } else {
       $disableLabel.text(originalDisableLabel);
@@ -121,7 +118,7 @@ $(function () {
   // for categories and entries - only show "create if they do not exist" if matching done by "title"
   // for users - only show "create if they do not exist" if matching done by "email"
   $(
-    '.categories-field-match select, .entries-field-match select, .users-field-match select',
+    '.categories-field-match select, .entries-field-match select, .users-field-match select'
   ).on('change', function (e) {
     var match = 'title';
     var $selectParent = $(this).parent();
@@ -229,7 +226,7 @@ $(function () {
       });
 
       $container.find('select').html(newOptions);
-    },
+    }
   );
 
   $('.field-extra-settings .element-group-section select').trigger('change');

--- a/src/web/assets/feedme/src/lib/selectize.js
+++ b/src/web/assets/feedme/src/lib/selectize.js
@@ -655,7 +655,7 @@
     module.exports = factory(
       require('jquery'),
       require('sifter'),
-      require('microplugin'),
+      require('microplugin')
     );
   } else {
     root.Selectize = factory(root.jQuery, root.Sifter, root.MicroPlugin);
@@ -722,7 +722,7 @@
       for (var i = 0; i < this._events[event].length; i++) {
         this._events[event][i].apply(
           this,
-          Array.prototype.slice.call(arguments, 1),
+          Array.prototype.slice.call(arguments, 1)
         );
       }
     },
@@ -1288,7 +1288,7 @@
       if (!self.settings.splitOn && self.settings.delimiter) {
         var delimiterEscaped = self.settings.delimiter.replace(
           /[-\/\\^$*+?.()|[\]{}]/g,
-          '\\$&',
+          '\\$&'
         );
         self.settings.splitOn = new RegExp('\\s*' + delimiterEscaped + '+\\s*');
       }
@@ -1392,7 +1392,7 @@
           if (self.isOpen) {
             self.positionDropdown.apply(self, arguments);
           }
-        },
+        }
       );
       $window.on('mousemove' + eventNS, function () {
         self.ignoreHover = false;
@@ -1593,7 +1593,7 @@
         if (self.settings.splitOn) {
           setTimeout(function () {
             var splitInput = $.trim(self.$control_input.val() || '').split(
-              self.settings.splitOn,
+              self.settings.splitOn
             );
             for (var i = 0, n = splitInput.length; i < n; i++) {
               self.createItem(splitInput[i]);
@@ -2089,14 +2089,14 @@
             .stop()
             .animate(
               {scrollTop: scroll_bottom},
-              animate ? self.settings.scrollDuration : 0,
+              animate ? self.settings.scrollDuration : 0
             );
         } else if (y < scroll) {
           self.$dropdown_content
             .stop()
             .animate(
               {scrollTop: scroll_top},
-              animate ? self.settings.scrollDuration : 0,
+              animate ? self.settings.scrollDuration : 0
             );
         }
       }
@@ -2110,7 +2110,7 @@
       if (self.settings.mode === 'single') return;
 
       self.$activeItems = Array.prototype.slice.apply(
-        self.$control.children(':not(input)').addClass('active'),
+        self.$control.children(':not(input)').addClass('active')
       );
       if (self.$activeItems.length) {
         self.hideInput();
@@ -2227,7 +2227,7 @@
         calculateScore = self.settings.score.apply(this, [query]);
         if (typeof calculateScore !== 'function') {
           throw new Error(
-            'Selectize "score" setting must be a function that returns a function',
+            'Selectize "score" setting must be a function that returns a function'
           );
         }
       }
@@ -2237,7 +2237,7 @@
         self.lastQuery = query;
         result = self.sifter.search(
           query,
-          $.extend(options, {score: calculateScore}),
+          $.extend(options, {score: calculateScore})
         );
         self.currentResults = result;
       } else {
@@ -2345,8 +2345,8 @@
               'optgroup',
               $.extend({}, self.optgroups[optgroup], {
                 html: html_children,
-              }),
-            ),
+              })
+            )
           );
         } else {
           html.push(groups[optgroup].join(''));
@@ -2627,7 +2627,7 @@
     getOption: function (value) {
       return this.getElementWithValue(
         value,
-        this.$dropdown_content.find('[data-selectable]'),
+        this.$dropdown_content.find('[data-selectable]')
       );
     },
 
@@ -2947,7 +2947,7 @@
               escape_html(self.items[i]) +
               '" selected="selected">' +
               escape_html(label) +
-              '</option>',
+              '</option>'
           );
         }
         if (!options.length && !this.$input.attr('multiple')) {
@@ -3112,7 +3112,7 @@
 
       if (self.$activeItems.length) {
         $tail = self.$control.children(
-          '.active:' + (direction > 0 ? 'last' : 'first'),
+          '.active:' + (direction > 0 ? 'last' : 'first')
         );
         caret = self.$control.children(':not(input)').index($tail);
         if (direction > 0) {
@@ -3393,13 +3393,13 @@
         id = data[self.settings.optgroupValueField] || '';
         html = html.replace(
           regex_tag,
-          '<$1 data-group="' + escape_replace(escape_html(id)) + '"',
+          '<$1 data-group="' + escape_replace(escape_html(id)) + '"'
         );
       }
       if (templateName === 'option' || templateName === 'item') {
         html = html.replace(
           regex_tag,
-          '<$1 data-value="' + escape_replace(escape_html(value || '')) + '"',
+          '<$1 data-value="' + escape_replace(escape_html(value || '')) + '"'
         );
       }
 
@@ -3687,7 +3687,7 @@
 
       instance = new Selectize(
         $input,
-        $.extend(true, {}, defaults, settings_element, settings_user),
+        $.extend(true, {}, defaults, settings_element, settings_user)
       );
     });
   };
@@ -3781,7 +3781,7 @@
           );
         },
       },
-      options,
+      options
     );
 
     self.setup = (function () {
@@ -3802,7 +3802,7 @@
         equalizeWidth: true,
         equalizeHeight: true,
       },
-      options,
+      options
     );
 
     this.getAdjacentOption = function ($option, direction) {
@@ -3903,7 +3903,7 @@
         className: 'remove',
         append: true,
       },
-      options,
+      options
     );
 
     var self = this;

--- a/src/web/assets/feedme/src/scss/_font-awesome.scss
+++ b/src/web/assets/feedme/src/scss/_font-awesome.scss
@@ -4752,8 +4752,7 @@ readers do not read off random characters that represent icons */
   font-style: normal;
   font-weight: 400;
   src: url('../fonts/fa-regular-400.eot');
-  src:
-    url('../fonts/fa-regular-400.eot?#iefix') format('embedded-opentype'),
+  src: url('../fonts/fa-regular-400.eot?#iefix') format('embedded-opentype'),
     url('../fonts/fa-regular-400.woff2') format('woff2'),
     url('../fonts/fa-regular-400.woff') format('woff'),
     url('../fonts/fa-regular-400.ttf') format('truetype'),
@@ -4774,8 +4773,7 @@ readers do not read off random characters that represent icons */
   font-style: normal;
   font-weight: 900;
   src: url('../fonts/fa-solid-900.eot');
-  src:
-    url('../fonts/fa-solid-900.eot?#iefix') format('embedded-opentype'),
+  src: url('../fonts/fa-solid-900.eot?#iefix') format('embedded-opentype'),
     url('../fonts/fa-solid-900.woff2') format('woff2'),
     url('../fonts/fa-solid-900.woff') format('woff'),
     url('../fonts/fa-solid-900.ttf') format('truetype'),

--- a/src/web/assets/feedme/src/scss/feed-me.css
+++ b/src/web/assets/feedme/src/scss/feed-me.css
@@ -4751,8 +4751,7 @@ readers do not read off random characters that represent icons */
   font-style: normal;
   font-weight: 400;
   src: url('../fonts/fa-regular-400.eot');
-  src:
-    url('../fonts/fa-regular-400.eot?#iefix') format('embedded-opentype'),
+  src: url('../fonts/fa-regular-400.eot?#iefix') format('embedded-opentype'),
     url('../fonts/fa-regular-400.woff2') format('woff2'),
     url('../fonts/fa-regular-400.woff') format('woff'),
     url('../fonts/fa-regular-400.ttf') format('truetype'),
@@ -4772,8 +4771,7 @@ readers do not read off random characters that represent icons */
   font-style: normal;
   font-weight: 900;
   src: url('../fonts/fa-solid-900.eot');
-  src:
-    url('../fonts/fa-solid-900.eot?#iefix') format('embedded-opentype'),
+  src: url('../fonts/fa-solid-900.eot?#iefix') format('embedded-opentype'),
     url('../fonts/fa-solid-900.woff2') format('woff2'),
     url('../fonts/fa-solid-900.woff') format('woff'),
     url('../fonts/fa-solid-900.ttf') format('truetype'),
@@ -4889,9 +4887,7 @@ body.ltr .table-feed-me .thin.action {
   position: relative;
   display: inline-block;
   background-image: linear-gradient(#fff, #fafafa);
-  box-shadow:
-    inset 0 0 0 1px rgba(0, 0, 0, 0.1),
-    0 0 0 1px rgba(0, 0, 0, 0.025),
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.025),
     0 1px 1px rgba(0, 0, 0, 0.1);
 }
 .feedme-mapping .select:after {

--- a/src/web/assets/feedme/src/scss/feed-me.scss
+++ b/src/web/assets/feedme/src/scss/feed-me.scss
@@ -143,9 +143,7 @@ body.ltr .table-feed-me .thin.action {
   position: relative;
   display: inline-block;
   background-image: linear-gradient(#fff, #fafafa);
-  box-shadow:
-    inset 0 0 0 1px rgba(0, 0, 0, 0.1),
-    0 0 0 1px rgba(0, 0, 0, 0.025),
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.025),
     0 1px 1px rgba(0, 0, 0, 0.1);
 
   &:after {

--- a/src/web/twig/variables/FeedMeVariable.php
+++ b/src/web/twig/variables/FeedMeVariable.php
@@ -3,14 +3,18 @@
 namespace craft\feedme\web\twig\variables;
 
 use Craft;
-use craft\elements\User as UserElement;
+use craft\feedme\helpers\FieldHelper;
+use craft\feedme\models\FeedModel;
 use craft\feedme\Plugin;
+use craft\fields\BaseRelationField;
+use craft\fields\Categories;
 use craft\fields\Checkboxes;
 use craft\fields\Color;
 use craft\fields\Country;
 use craft\fields\Date;
 use craft\fields\Dropdown;
 use craft\fields\Email;
+use craft\fields\Entries;
 use craft\fields\Icon;
 use craft\fields\Lightswitch;
 use craft\fields\Money;
@@ -20,14 +24,13 @@ use craft\fields\PlainText;
 use craft\fields\RadioButtons;
 use craft\fields\Time;
 use craft\fields\Url;
+use craft\fields\Users;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\Html;
 use craft\helpers\UrlHelper;
 use craft\models\CategoryGroup;
-use craft\models\Section;
 use craft\models\TagGroup;
 use DateTime;
-use Illuminate\Support\Collection;
 use yii\di\ServiceLocator;
 
 /**
@@ -141,79 +144,22 @@ class FeedMeVariable extends ServiceLocator
 
     public function getAssetSourcesByField($field): ?array
     {
-        $sources = [];
-
-        if (!$field) {
-            return null;
-        }
-
-        if (is_array($field->sources)) {
-            foreach ($field->sources as $source) {
-                [, $uid] = explode(':', $source);
-
-                $sources[] = Craft::$app->volumes->getVolumeByUid($uid);
-            }
-        } elseif ($field->sources === '*') {
-            $sources = Craft::$app->volumes->getAllVolumes();
-        }
-
-        return $sources;
+        return FieldHelper::getAssetSourcesByField($field);
     }
 
     public function getCategorySourcesByField($field): ?CategoryGroup
     {
-        if (!$field) {
-            return null;
-        }
-
-        [, $uid] = explode(':', $field->source);
-
-        return Craft::$app->categories->getGroupByUid($uid);
+        return FieldHelper::getCategorySourcesByField($field);
     }
 
     public function getEntrySourcesByField($field): ?array
     {
-        $sources = [];
-
-        if (!$field) {
-            return null;
-        }
-
-        if (is_array($field->sources)) {
-            foreach ($field->sources as $source) {
-                if ($source == 'singles') {
-                    foreach (Craft::$app->getEntries()->getAllSections() as $section) {
-                        if ($section->type == 'single') {
-                            $sources[] = $section;
-                        }
-                    }
-                } else {
-                    [, $uid] = explode(':', $source);
-
-                    $section = Craft::$app->getEntries()->getSectionByUid($uid);
-                    // only add to sources, if this was a section that we were able to retrieve (native section's uid)
-                    // https://github.com/craftcms/feed-me/issues/1186
-                    if ($section) {
-                        $sources[] = $section;
-                    }
-                }
-            }
-        } elseif ($field->sources === '*') {
-            $sources = Craft::$app->getEntries()->getAllSections();
-        }
-
-        return $sources;
+        return FieldHelper::getEntrySourcesByField($field);
     }
 
     public function getTagSourcesByField($field): ?TagGroup
     {
-        if (!$field) {
-            return null;
-        }
-
-        [, $uid] = explode(':', $field->source);
-
-        return Craft::$app->tags->getTagGroupByUid($uid);
+        return FieldHelper::getTagSourcesByField($field);
     }
 
 
@@ -223,124 +169,22 @@ class FeedMeVariable extends ServiceLocator
 
     public function getElementLayoutByField($type, $field): ?array
     {
-        $source = null;
-
-        if ($type === 'craft\fields\Assets') {
-            $source = $this->getAssetSourcesByField($field)[0] ?? null;
-        } elseif ($type === 'craft\fields\Categories') {
-            $source = $this->getCategorySourcesByField($field);
-        } elseif ($type === 'craft\fields\Entries') {
-            /** @var Section $section */
-            $section = $this->getEntrySourcesByField($field)[0] ?? null;
-
-            if ($section) {
-                $source = $section->getEntryTypes()[0] ?? null;
-            }
-        } elseif ($type === 'craft\fields\Tags') {
-            $source = $this->getTagSourcesByField($field);
-        }
-
-        if (!$source || !$source->fieldLayoutId) {
-            return null;
-        }
-
-        if (($fieldLayout = Craft::$app->getFields()->getLayoutById($source->fieldLayoutId)) !== null) {
-            return $fieldLayout->getCustomFields();
-        }
-
-        return null;
+        return FieldHelper::getElementLayoutByField($type, $field);
     }
 
     public function getUserLayoutByField(): ?array
     {
-        $layoutId = Craft::$app->getFields()->getLayoutByType(UserElement::class)->id;
-
-        if (!$layoutId) {
-            return null;
-        }
-
-        if (($fieldLayout = Craft::$app->getFields()->getLayoutById($layoutId)) !== null) {
-            return $fieldLayout->getCustomFields();
-        }
-
-        return null;
+        return FieldHelper::getUserLayoutByField();
     }
 
     public function getAssetFolderBySourceId($id): array
     {
-        $folders = Craft::$app->getAssets()->getFolderTreeByVolumeIds([$id]);
-
-        $return = [];
-
-        $return[''] = Craft::t('feed-me', 'Don\'t Import');
-
-        foreach ($folders as $folder) {
-            $return[] = [
-                'value' => 'root',
-                'label' => Craft::t('feed-me', 'Root Folder'),
-            ];
-
-            $children = $folder->getChildren();
-
-            if ($children) {
-                foreach ($children as $childFolder) {
-                    $return[] = [
-                        'value' => $childFolder['id'],
-                        'label' => $childFolder['name'],
-                    ];
-                }
-            }
-        }
-
-        return $return;
+        return FieldHelper::getAssetFolderBySourceId($id);
     }
 
     public function fieldCanBeUniqueId($field): bool
     {
-        $type = $field['type'] ?? 'attribute';
-
-        if (isset($field['type']) && $field['handle'] === 'parent') {
-            $type = 'parent';
-        }
-
-        if (is_object($field)) {
-            $type = get_class($field);
-        }
-
-        $supportedFields = [
-            Checkboxes::class,
-            Color::class,
-            Date::class,
-            Dropdown::class,
-            Email::class,
-            Lightswitch::class,
-            MultiSelect::class,
-            Number::class,
-            PlainText::class,
-            RadioButtons::class,
-            Url::class,
-        ];
-
-        $supportedValues = [
-            'assets',
-            'attribute',
-            'parent',
-        ];
-
-        $supported = array_merge($supportedFields, $supportedValues);
-
-        if (in_array($type, $supported, true)) {
-            return true;
-        }
-
-        // Include any field types that extend one of the above
-        foreach ($supportedFields as $supportedField) {
-            if (is_a($type, $supportedField, true)) {
-                return true;
-            }
-        }
-
-        return false;
+        return FieldHelper::fieldCanBeUniqueId($field);
     }
 
     public function supportedSubField($class): bool
@@ -376,17 +220,6 @@ class FeedMeVariable extends ServiceLocator
      */
     public function fieldHasOnlyCustomSources(mixed $field = null): bool
     {
-        if ($field === null) {
-            return false;
-        }
-
-        if (!isset($field['sources'])) {
-            return false;
-        }
-
-        $sources = new Collection($field['sources']);
-        $nativeSources = $sources->filter(fn(string $source) => !str_starts_with($source, 'custom:'));
-
-        return $nativeSources->isEmpty();
+        return FieldHelper::fieldHasOnlyCustomSources($field);
     }
 }

--- a/src/web/twig/variables/FeedMeVariable.php
+++ b/src/web/twig/variables/FeedMeVariable.php
@@ -222,4 +222,34 @@ class FeedMeVariable extends ServiceLocator
     {
         return FieldHelper::fieldHasOnlyCustomSources($field);
     }
+
+    /**
+     * Return an array of custom field by which the relation field elements can be matched.
+     *
+     * @param string $className
+     * @param BaseRelationField|null $field
+     * @return array
+     */
+    public function getRelationFieldMatchOptions(string $className, FeedModel $feed, ?BaseRelationField $field = null): array
+    {
+        $allowedFields = [];
+        $matchAttributes = [];
+
+        $feedMeField = match ($className) {
+            Categories::class => \craft\feedme\fields\Categories::class,
+            Entries::class => \craft\feedme\fields\Entries::class,
+            Users::class => \craft\feedme\fields\users::class,
+            default => null,
+        };
+
+        if ($feedMeField !== null) {
+            $allowedFields = $feedMeField::getMatchFields($feed, $field);
+        }
+
+        foreach ($allowedFields as $allowedField) {
+            $matchAttributes[$allowedField->handle] = $allowedField->name;
+        }
+
+        return $matchAttributes;
+    }
 }

--- a/src/web/twig/variables/FeedMeVariable.php
+++ b/src/web/twig/variables/FeedMeVariable.php
@@ -238,7 +238,7 @@ class FeedMeVariable extends ServiceLocator
         $feedMeField = match ($className) {
             Categories::class => \craft\feedme\fields\Categories::class,
             Entries::class => \craft\feedme\fields\Entries::class,
-            Users::class => \craft\feedme\fields\users::class,
+            Users::class => \craft\feedme\fields\Users::class,
             default => null,
         };
 


### PR DESCRIPTION
### Description

When mapping relation fields, for some relation field types, you can choose to map them not only via a predefined list of attributes but also some of the custom fields. 

Historically, the list of available match options was a list of all the fields (not just ones that are related to the sections/category group, etc., that are used by the relation field) that were deemed fit to be used as a unique identifier (a selection of the “simple” fields). 

With the changes in Craft 5, that has become less intuitive to use.

This PR changes this behaviour so that:
- for the Users field and Author attribute
    - only list the custom fields from the user field layout (there’s only one);
- for the Entries field
    - only list the custom fields from the field layouts attached to the sources used by the field; 
    - if only custom sources are selected by the Entries field, show all the custom fields;
    - if there’s a mixture of custom and native sources, list the custom fields from the field layouts attached to the sources used by the field, followed by a list of all the custom fields;
- for the Categories field
    - only list the custom fields from the field layout attached to the category group used by the field; 
    - if a custom source is selected for the Categories field, show all the custom fields
- for the Parent attribute for Entries and Categories (when they’re hierarchical)
    - only list the custom fields from the layout linked to the entry type or category group selected when defining the feed

To be clear, in all the above cases, the list of fields is further filtered down to only the ones that can be used as a unique identifier.

### Related issues
#1572 
