### PR TITLE
Added Google Maps subfields `formatted` and `raw`

### DIFF
--- a/src/templates/_includes/fields/google-maps.html
+++ b/src/templates/_includes/fields/google-maps.html
@@ -50,6 +50,14 @@
         'handle': 'zoom',
         'label': 'Zoom'
     },
+    {
+        'handle': 'formatted',
+        'label': 'Formatted'
+    },
+    {
+        'handle': 'raw',
+        'label': 'Raw'
+    }
 ]) %}
 
 {# Loop through all subfields #}


### PR DESCRIPTION
Adds support for two new subfields in Google Maps, as described here:

https://github.com/doublesecretagency/craft-googlemaps/issues/128

This PR explicitly targets the Craft 4 branch, an identical PR was submitted to the Craft 5 branch.