### PR TITLE
Prune logs table when processed feeds

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -17,6 +17,7 @@ use craft\feedme\services\Service;
 use craft\feedme\web\twig\Extension;
 use craft\feedme\web\twig\variables\FeedMeVariable;
 use craft\helpers\UrlHelper;
+use craft\services\Gc;
 use craft\web\twig\variables\CraftVariable;
 use craft\web\UrlManager;
 use yii\base\Event;
@@ -86,6 +87,7 @@ class Plugin extends \craft\base\Plugin
         $this->_registerCpRoutes();
         $this->_registerTwigExtensions();
         $this->_registerVariables();
+        $this->_registerGc();
     }
 
     /**
@@ -169,5 +171,16 @@ class Plugin extends \craft\base\Plugin
         Event::on(CraftVariable::class, CraftVariable::EVENT_INIT, function(Event $event) {
             $event->sender->set('feedme', FeedMeVariable::class);
         });
+    }
+
+    private function _registerGc(): void
+    {
+        Event::on(
+            Gc::class,
+            Gc::EVENT_RUN,
+            function(Event $event) {
+                $this->getLogs()->prune();
+            }
+        );
     }
 }

--- a/src/services/Logs.php
+++ b/src/services/Logs.php
@@ -5,6 +5,7 @@ namespace craft\feedme\services;
 use Craft;
 use craft\base\Component;
 use craft\db\Query;
+use craft\db\Table;
 use craft\feedme\Plugin;
 use craft\helpers\App;
 use craft\helpers\Db;
@@ -57,6 +58,7 @@ class Logs extends Component
 
     public const LOG_CATEGORY = 'feed-me';
     public const LOG_TABLE = '{{%feedme_logs}}';
+    public const LOG_TABLE_LIMIT = 300;
 
     public const LOG_LEVEL_MAP = [
         Logger::LEVEL_ERROR => 'error',
@@ -124,6 +126,22 @@ class Logs extends Component
             ->execute();
     }
 
+    public function prune(): void
+    {
+        $ids = (new Query())
+            ->select(['id'])
+            ->from(self::LOG_TABLE)
+            ->orderBy(['log_time' => SORT_DESC])
+            ->limit(self::LOG_TABLE_LIMIT)
+            ->column();
+
+        if (count($ids)) {
+            Craft::$app->getDb()->createCommand()
+                ->delete(self::LOG_TABLE, ['not', ['in', 'id', $ids]])
+                ->execute();
+        }
+    }
+
     /**
      * @param null $type
      * @return array
@@ -138,7 +156,7 @@ class Logs extends Component
             ->from(self::LOG_TABLE)
 
             // Hard-coded until pagination is implemented
-            ->limit(300);
+            ->limit(self::LOG_TABLE_LIMIT);
 
         if ($type) {
             $query->andWhere(['level' => self::logLevelInt($type)]);

--- a/src/services/Logs.php
+++ b/src/services/Logs.php
@@ -5,7 +5,6 @@ namespace craft\feedme\services;
 use Craft;
 use craft\base\Component;
 use craft\db\Query;
-use craft\db\Table;
 use craft\feedme\Plugin;
 use craft\helpers\App;
 use craft\helpers\Db;

--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -83,6 +83,8 @@ class Process extends Component
             $gc->run(true);
         }
 
+        Plugin::getInstance()->getLogs()->prune();
+
         $this->_data = $feedData;
         $this->_service = $feed->element;
 

--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -81,9 +81,9 @@ class Process extends Component
             $gc = Craft::$app->getGc();
             $gc->deleteAllTrashed = true;
             $gc->run(true);
+        } else {
+            Plugin::getInstance()->getLogs()->prune();
         }
-
-        Plugin::getInstance()->getLogs()->prune();
 
         $this->_data = $feedData;
         $this->_service = $feed->element;


### PR DESCRIPTION
### Description
The logs UI currently has a hard-coded limit of 300, so there's no point in storing more records than that in the `feedme_logs` table.

This prunes the table to the most recent 300 on feed processing and garbage collection.

### Related issues
Fixes #1494
