### PR TITLE
default to "auto" format for time fields

### DIFF
--- a/src/fields/Time.php
+++ b/src/fields/Time.php
@@ -52,7 +52,7 @@ class Time extends Field implements FieldInterface
             return null;
         }
 
-        $formatting = Hash::get($this->fieldInfo, 'options.match');
+        $formatting = Hash::get($this->fieldInfo, 'options.match') ?? 'auto';
 
         $timeValue = DateHelper::parseString($value, $formatting);
 


### PR DESCRIPTION
### Description
Default to the “auto” format for Time fields. 
This is helpful if you have a feed that maps the Time field and that feed was created before `5.10.0` and `6.7.0`. 

(Alternative: you can also resave the feed.)


### Related issues
#1593
