### PR TITLE
wrap getting field type in try-catch

### DIFF
--- a/src/web/twig/variables/FeedMeVariable.php
+++ b/src/web/twig/variables/FeedMeVariable.php
@@ -300,7 +300,11 @@ class FeedMeVariable extends ServiceLocator
 
     public function fieldCanBeUniqueId($field): bool
     {
-        $type = $field['type'] ?? 'attribute';
+        try {
+            $type = $field['type'] ?? 'attribute';
+        } catch (\Throwable $e) {
+            return false;
+        }
 
         if (isset($field['type']) && $field['handle'] === 'parent') {
             $type = 'parent';


### PR DESCRIPTION
### Description
Wrap getting the field’s type in try-catch so that, e.g. the mapping template doesn’t crash if the type can’t be retrieved.


### Related issues
#1574 
