### PR TITLE
Feature/1584 batched job

### DIFF
--- a/src/base/DataType.php
+++ b/src/base/DataType.php
@@ -4,6 +4,7 @@ namespace craft\feedme\base;
 
 use Cake\Utility\Hash;
 use Craft;
+use craft\base\Batchable;
 use craft\base\Component;
 use craft\helpers\UrlHelper;
 
@@ -12,8 +13,16 @@ use craft\helpers\UrlHelper;
  * @property-read mixed $name
  * @property-read mixed $class
  */
-abstract class DataType extends Component
+abstract class DataType extends Component implements Batchable
 {
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var array
+     */
+    protected array $feedData = [];
+
     // Public
     // =========================================================================
 
@@ -58,5 +67,31 @@ abstract class DataType extends Component
 
         // Replace the mapping value with the actual URL
         $feed->paginationUrl = $url;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSlice(int $offset, int $limit): iterable
+    {
+        $feedData = $this->feedData;
+
+        if ($offset) {
+            $feedData = array_slice($feedData, $offset);
+        }
+
+        if ($limit) {
+            $feedData = array_slice($feedData, 0, $limit);
+        }
+
+        return $feedData;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function count(): int
+    {
+        return count($this->feedData);
     }
 }

--- a/src/console/controllers/FeedsController.php
+++ b/src/console/controllers/FeedsController.php
@@ -5,6 +5,7 @@ namespace craft\feedme\console\controllers;
 use craft\feedme\Plugin;
 use craft\feedme\queue\jobs\FeedImport;
 use craft\helpers\Console;
+use craft\helpers\Queue;
 use yii\console\Controller;
 use yii\console\ExitCode;
 
@@ -108,7 +109,7 @@ class FeedsController extends Controller
         $this->stdout($feed->name, Console::FG_CYAN);
         $this->stdout(' ... ');
 
-        $this->module->queue->push(new FeedImport([
+        Queue::push(new FeedImport([
             'feed' => $feed,
             'limit' => $limit,
             'offset' => $offset,

--- a/src/controllers/FeedsController.php
+++ b/src/controllers/FeedsController.php
@@ -9,6 +9,7 @@ use craft\feedme\models\FeedModel;
 use craft\feedme\Plugin;
 use craft\feedme\queue\jobs\FeedImport;
 use craft\helpers\Json;
+use craft\helpers\Queue;
 use craft\helpers\StringHelper;
 use craft\web\Controller;
 use Exception;
@@ -344,7 +345,7 @@ class FeedsController extends Controller
             Craft::$app->getSession()->setNotice(Craft::t('feed-me', 'Feed processing started.'));
 
             // Create the import task
-            $this->module->queue->push(new FeedImport([
+            Queue::push(new FeedImport([
                 'feed' => $feed,
                 'limit' => $limit,
                 'offset' => $offset,
@@ -363,7 +364,7 @@ class FeedsController extends Controller
 
             // Create the import task only if provided the correct passkey
             if ($proceed) {
-                $this->module->queue->push(new FeedImport([
+                Queue::push(new FeedImport([
                     'feed' => $feed,
                     'limit' => $limit,
                     'offset' => $offset,

--- a/src/datatypes/Csv.php
+++ b/src/datatypes/Csv.php
@@ -112,6 +112,7 @@ class Csv extends DataType implements DataTypeInterface
             $array = Plugin::$plugin->data->findPrimaryElement($primaryElement, $array);
         }
 
+        $this->feedData = $array;
         return ['success' => true, 'data' => $array];
     }
 

--- a/src/datatypes/DataBatcher.php
+++ b/src/datatypes/DataBatcher.php
@@ -4,13 +4,9 @@
 namespace craft\feedme\datatypes;
 
 use craft\base\Batchable;
-use yii\db\Connection as YiiConnection;
-use yii\db\Query as YiiQuery;
-use yii\db\QueryInterface;
 
 class DataBatcher implements Batchable
 {
-
     public function __construct(
         private array $data,
     ) {

--- a/src/datatypes/DataBatcher.php
+++ b/src/datatypes/DataBatcher.php
@@ -1,0 +1,44 @@
+<?php
+
+
+namespace craft\feedme\datatypes;
+
+use craft\base\Batchable;
+use yii\db\Connection as YiiConnection;
+use yii\db\Query as YiiQuery;
+use yii\db\QueryInterface;
+
+class DataBatcher implements Batchable
+{
+
+    public function __construct(
+        private array $data,
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function count(): int
+    {
+        return count($this->data);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSlice(int $offset, int $limit): iterable
+    {
+        $slice = $this->data;
+
+        if ($offset) {
+            $slice = array_slice($slice, $offset);
+        }
+
+        if ($limit) {
+            $slice = array_slice($slice, 0, $limit);
+        }
+
+        return $slice;
+    }
+}

--- a/src/datatypes/GoogleSheet.php
+++ b/src/datatypes/GoogleSheet.php
@@ -87,6 +87,7 @@ class GoogleSheet extends DataType implements DataTypeInterface
             $array = Plugin::$plugin->data->findPrimaryElement($primaryElement, $array);
         }
 
+        $this->feedData = $array;
         return ['success' => true, 'data' => $array];
     }
 }

--- a/src/datatypes/Json.php
+++ b/src/datatypes/Json.php
@@ -85,6 +85,7 @@ class Json extends DataType implements DataTypeInterface
             $array = Plugin::$plugin->data->findPrimaryElement($primaryElement, $array);
         }
 
+        $this->feedData = $array;
         return ['success' => true, 'data' => $array];
     }
 }

--- a/src/datatypes/Xml.php
+++ b/src/datatypes/Xml.php
@@ -83,6 +83,7 @@ class Xml extends DataType implements DataTypeInterface
             $array = Plugin::$plugin->data->findPrimaryElement($primaryElement, $array);
         }
 
+        $this->feedData = $array;
         return ['success' => true, 'data' => $array];
     }
 }

--- a/src/queue/jobs/FeedImport.php
+++ b/src/queue/jobs/FeedImport.php
@@ -2,10 +2,16 @@
 
 namespace craft\feedme\queue\jobs;
 
+use Cake\Utility\Hash;
 use Craft;
+use craft\base\Batchable;
+use craft\feedme\datatypes\DataBatcher;
+use craft\feedme\events\FeedProcessEvent;
 use craft\feedme\models\FeedModel;
 use craft\feedme\Plugin;
-use craft\queue\BaseJob;
+use craft\feedme\services\Process;
+use craft\helpers\Queue;
+use craft\queue\BaseBatchedJob;
 use Throwable;
 use yii\queue\RetryableJobInterface;
 
@@ -13,7 +19,7 @@ use yii\queue\RetryableJobInterface;
  *
  * @property-read mixed $ttr
  */
-class FeedImport extends BaseJob implements RetryableJobInterface
+class FeedImport extends BaseBatchedJob implements RetryableJobInterface
 {
     // Properties
     // =========================================================================
@@ -44,6 +50,27 @@ class FeedImport extends BaseJob implements RetryableJobInterface
      */
     public bool $continueOnError = true;
 
+    /**
+     * @var mixed The Unix timestamp with microseconds of when the feed import started being processed
+     * @since 5.11.0
+     */
+    public mixed $startTime = null;
+
+    /**
+     * @inheritdoc
+     */
+    public int $batchSize = 2;
+
+    /**
+     * @var array The Feed's settings as prepared by beforeProcessFeed()
+     */
+    private array $_feedSettings = [];
+
+    /**
+     * @var int The index of currently processed item in current batch
+     */
+    private int $_index = 0;
+
     // Public Methods
     // =========================================================================
 
@@ -65,72 +92,107 @@ class FeedImport extends BaseJob implements RetryableJobInterface
     }
 
     /**
+     * @inheritdoc
+     */
+    protected function loadData(): Batchable
+    {
+        $feedData = $this->feed->getFeedData();
+
+        if ($this->offset) {
+            $feedData = array_slice($feedData, $this->offset);
+        }
+
+        if ($this->limit) {
+            $feedData = array_slice($feedData, 0, $this->limit);
+        }
+
+        $data = $feedData;
+
+        // Our main data-parsing function. Handles the actual data values, defaults and field options
+        foreach ($feedData as $key => $nodeData) {
+            if (!is_array($nodeData)) {
+                $nodeData = [$nodeData];
+            }
+
+            $data[$key] = Hash::flatten($nodeData, '/');
+        }
+
+        $data = array_values($data);
+
+        // Fire an 'onBeforeProcessFeed' event
+        $event = new FeedProcessEvent([
+            'feed' => $this->feed,
+            'feedData' => $data,
+        ]);
+
+        Plugin::$plugin->process->trigger(Process::EVENT_BEFORE_PROCESS_FEED, $event);
+
+        if (!$event->isValid) {
+            return new DataBatcher([]);
+        }
+
+        // Allow event to modify the feed data
+        $data = $event->feedData;
+
+        return new DataBatcher($data);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function processItem(mixed $item): void
+    {
+        try {
+            Plugin::$plugin->process->processFeed($this->_index, $this->_feedSettings, $this->processedElementIds, $item, $this->batchIndex);
+        } catch (Throwable $e) {
+            if (!$this->continueOnError) {
+                throw $e;
+            }
+
+            // We want to catch any issues in each iteration of the loop (and log them), but this allows the
+            // rest of the feed to continue processing.
+            Plugin::error('`{e} - {f}: {l}`.', ['e' => $e->getMessage(), 'f' => basename($e->getFile()), 'l' => $e->getLine()]);
+            Craft::$app->getErrorHandler()->logException($e);
+        }
+
+        $this->_index++;
+    }
+    /**
      * @inheritDoc
      */
     public function execute($queue): void
     {
-        try {
-            $feedData = $this->feed->getFeedData();
+        $processService = Plugin::$plugin->getProcess();
+        if ($this->itemOffset == 0) {
+            $processService->beforeProcessFeed($this->feed, (array)$this->data());
+        }
 
-            if ($this->offset) {
-                $feedData = array_slice($feedData, $this->offset);
-            }
+        if (!$this->startTime) {
+            $this->startTime = $processService->time_start;
+        }
 
-            if ($this->limit) {
-                $feedData = array_slice($feedData, 0, $this->limit);
-            }
+        if (empty($this->_feedSettings)) {
+            $this->_feedSettings = $processService->getFeedSettings($this->feed, (array)$this->data());
+        }
 
-            // Do we even have any data to process?
-            if (!$feedData) {
-                Plugin::info('No feed items to process.');
-                return;
-            }
+        parent::execute($queue);
 
-            $feedSettings = Plugin::$plugin->process->beforeProcessFeed($this->feed, $feedData);
-
-            $feedData = $feedSettings['feedData'];
-
-            $totalSteps = count($feedData);
-
-            $index = 0;
-
-            foreach ($feedData as $data) {
-                try {
-                    Plugin::$plugin->process->processFeed($index, $feedSettings, $this->processedElementIds);
-                } catch (Throwable $e) {
-                    if (!$this->continueOnError) {
-                        throw $e;
-                    }
-
-                    // We want to catch any issues in each iteration of the loop (and log them), but this allows the
-                    // rest of the feed to continue processing.
-                    Plugin::error('`{e} - {f}: {l}`.', ['e' => $e->getMessage(), 'f' => basename($e->getFile()), 'l' => $e->getLine()]);
-                    Craft::$app->getErrorHandler()->logException($e);
-                }
-
-                $this->setProgress($queue, $index++ / $totalSteps);
-            }
-
-            // Check if we need to paginate the feed to run again
+        // Check if we need to paginate the feed to run again
+        if ($this->itemOffset == $this->totalItems()) {
             if ($this->feed->getNextPagination()) {
                 Queue::push(new self([
                     'feed' => $this->feed,
                     'limit' => $this->limit,
                     'offset' => $this->offset,
                     'processedElementIds' => $this->processedElementIds,
+                    'startTime' => $this->startTime,
                 ]));
             } else {
                 // Only perform the afterProcessFeed function after any/all pagination is done
-                Plugin::$plugin->process->afterProcessFeed($feedSettings, $this->feed, $this->processedElementIds);
+                $processService->afterProcessFeed($this->_feedSettings, $this->feed, $this->processedElementIds, $this->startTime);
             }
-        } catch (Throwable $e) {
-            // Even though we catch errors on each step of the loop, make sure to catch errors that can be anywhere
-            // else in this function, just to be super-safe and not cause the queue job to die.
-            Plugin::error('`{e} - {f}: {l}`.', ['e' => $e->getMessage(), 'f' => basename($e->getFile()), 'l' => $e->getLine()]);
-            Craft::$app->getErrorHandler()->logException($e);
         }
     }
-
 
     // Protected Methods
     // =========================================================================

--- a/src/queue/jobs/FeedImport.php
+++ b/src/queue/jobs/FeedImport.php
@@ -113,7 +113,7 @@ class FeedImport extends BaseJob implements RetryableJobInterface
 
             // Check if we need to paginate the feed to run again
             if ($this->feed->getNextPagination()) {
-                Plugin::getInstance()->queue->push(new self([
+                Queue::push(new self([
                     'feed' => $this->feed,
                     'limit' => $this->limit,
                     'offset' => $this->offset,

--- a/src/queue/jobs/FeedImport.php
+++ b/src/queue/jobs/FeedImport.php
@@ -57,11 +57,6 @@ class FeedImport extends BaseBatchedJob implements RetryableJobInterface
     public mixed $startTime = null;
 
     /**
-     * @inheritdoc
-     */
-    public int $batchSize = 2;
-
-    /**
      * @var array The Feed's settings as prepared by beforeProcessFeed()
      */
     private array $_feedSettings = [];

--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -603,7 +603,8 @@ class Process extends Component
             return;
         }
 
-        $feedSettings = $this->beforeProcessFeed($feed, $feedData);
+        $this->beforeProcessFeed($feed, $feedData);
+        $feedSettings = $this->getFeedSettings($feed, $feedData);
 
         foreach ($feedData as $key => $data) {
             $this->processFeed($key, $feedSettings, $processedElementIds, $data);

--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -157,7 +157,7 @@ class Process extends Component
      * @return mixed|void
      * @throws \Exception
      */
-    public function processFeed($step, $feed, &$processedElementIds, $feedData, $batchIndex)
+    public function processFeed($step, $feed, &$processedElementIds, $feedData, $batchIndex = 0)
     {
         $attributeData = [];
         $fieldData = [];
@@ -606,7 +606,7 @@ class Process extends Component
         $feedSettings = $this->beforeProcessFeed($feed, $feedData);
 
         foreach ($feedData as $key => $data) {
-            $this->processFeed($key, $feedSettings, $processedElementIds);
+            $this->processFeed($key, $feedSettings, $processedElementIds, $data);
         }
 
         // Check if we need to paginate the feed to run again

--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -38,17 +38,12 @@ class Process extends Component
     /**
      * @var
      */
-    private mixed $_time_start = null;
+    public mixed $time_start = null;
 
     /**
      * @var ElementInterface
      */
     private ElementInterface $_service;
-
-    /**
-     * @var array
-     */
-    private array $_data;
 
 
     // Public Methods
@@ -85,13 +80,22 @@ class Process extends Component
             Plugin::getInstance()->getLogs()->prune();
         }
 
-        $this->_data = $feedData;
+        // Set our start time to track feed processing time
+        $this->time_start = microtime(true);
+    }
+
+    /**
+     * @param FeedModel $feed
+     * @param array $feedData
+     * @return array
+     * @throws \yii\base\InvalidConfigException
+     */
+    public function getFeedSettings(FeedModel $feed, array $feedData)
+    {
+        $data = $feedData;
         $this->_service = $feed->element;
 
         $return = $feed->attributes;
-
-        // Set our start time to track feed processing time
-        $this->_time_start = microtime(true);
 
         App::maxPowerCaptain();
 
@@ -135,35 +139,10 @@ class Process extends Component
             $return['existingElements'] = $query->ids();
         }
 
-        // Our main data-parsing function. Handles the actual data values, defaults and field options
-        foreach ($feedData as $key => $nodeData) {
-            if (!is_array($nodeData)) {
-                $nodeData = [$nodeData];
-            }
-
-            $this->_data[$key] = Hash::flatten($nodeData, '/');
-        }
-
-        $this->_data = array_values($this->_data);
-
-        // Fire an 'onBeforeProcessFeed' event
-        $event = new FeedProcessEvent([
-            'feed' => $feed,
-            'feedData' => $this->_data,
-        ]);
-
-        $this->trigger(self::EVENT_BEFORE_PROCESS_FEED, $event);
-
-        if (!$event->isValid) {
-            return;
-        }
-
-        // Allow event to modify the feed data
-        $this->_data = $event->feedData;
-
         // Return the feed data
-        $return['feedData'] = $this->_data;
+        $return['feedData'] = $data;
 
+        Plugin::$stepKey = null;
         Plugin::info('Finished preparing for feed processing.');
 
         return $return;
@@ -174,13 +153,15 @@ class Process extends Component
      * @param $feed
      * @param $processedElementIds
      * @param $feedData
+     * @param $batchIndex
      * @return mixed|void
      * @throws \Exception
      */
-    public function processFeed($step, $feed, &$processedElementIds, $feedData = null)
+    public function processFeed($step, $feed, &$processedElementIds, $feedData, $batchIndex)
     {
         $attributeData = [];
         $fieldData = [];
+        $batchIndex++;
 
         // We can opt-out of updating certain elements if a field is switched on
         $skipUpdateFieldHandle = Plugin::$plugin->service->getConfig('skipUpdateFieldHandle', $feed['id']);
@@ -199,18 +180,15 @@ class Process extends Component
             Plugin::error('Error `{i}`.', ['i' => Json::encode($step)]);
         }
 
-        if (!is_array($this->_data) || empty($this->_data[0])) {
+        if (!is_array($feedData) || empty($feedData)) {
             Plugin::info('There is no data in the feed to process.');
             return;
         }
 
-        Plugin::info('Starting processing of node `#{i}`.', ['i' => ($step + 1)]);
+        Plugin::info('Starting processing of node `#{i}` in batch `{j}`.', ['i' => ($step + 1), 'j' => $batchIndex]);
 
         // Set up a model for this Element Type
         $element = $this->_service->setModel($feed);
-
-        // From the raw data in our feed, we need to fix it up so its Craft-ready for the element and fields
-        $feedData = $feedData ?? $this->_data[$step];
 
         // We need to first find a potentially existing element, and to do that, we need to prep just the fields
         // that are selected as the unique identifier. We prep everything else later on.
@@ -471,7 +449,10 @@ class Process extends Component
             $unchangedContent = DataHelper::compareElementContent($contentData, $existingElement);
 
             if ($unchangedContent) {
-                $info = Craft::t('feed-me', 'Node `#{i}` skipped. No content has changed.', ['i' => ($step + 1)]);
+                $info = Craft::t(
+                    'feed-me',
+                    'Node `#{i}` in batch `{j}` skipped. No content has changed.',
+                    ['i' => ($step + 1), 'j' => $batchIndex]);
 
                 Plugin::info($info);
                 Plugin::debug($info);
@@ -519,7 +500,7 @@ class Process extends Component
             // Store our successfully processed element for feedback in logs, but also in case we're deleting
             $processedElementIds[] = $element->id;
 
-            Plugin::info('Finished processing of node `#{i}`.', ['i' => ($step + 1)]);
+            Plugin::info('Finished processing of node `#{i}` in batch `{j}`.', ['i' => ($step + 1), 'j' => $batchIndex]);
 
             // Sleep if required
             $sleepTime = Plugin::$plugin->service->getConfig('sleepTime', $feed['id']);
@@ -542,8 +523,9 @@ class Process extends Component
      * @param $settings
      * @param $feed
      * @param $processedElementIds
+     * @param $startTime
      */
-    public function afterProcessFeed($settings, $feed, $processedElementIds): void
+    public function afterProcessFeed($settings, $feed, $processedElementIds, $startTime = null): void
     {
         if ((int)DuplicateHelper::isDelete($feed) + (int)DuplicateHelper::isDisable($feed) + (int)DuplicateHelper::isDisableForSite($feed) > 1) {
             Plugin::info("You can't have Delete and Disabled enabled at the same time as an Import Strategy.");
@@ -577,7 +559,8 @@ class Process extends Component
 
         // Log the total time taken to process the feed
         $time_end = microtime(true);
-        $execution_time = number_format(($time_end - $this->_time_start), 2);
+        $time_start = $startTime ?? $this->time_start;
+        $execution_time = number_format(($time_end - $time_start), 2);
 
         Plugin::$stepKey = null;
 


### PR DESCRIPTION
### Description
Feeds are now processed as batched jobs. 

Notes:
- Pagination is still supported, as it was before. If you have a feed that has 3 pages, each page has, e.g. 200 primary elements to be processed, then each page will take two batches.
- `services/Process.php->processFeed()` - the last parameter (`$feedData`) is no longer optional
- `services/Process.php->afterProcessFeed()` - now accepts the 4th param (`$startTime`); it’s needed for the time calculations to work correctly for the paginated view; if omitted, the time calculation will still work, but as before - timing only the last page
- `services/Process.php->beforeProcessFeed()` is now split into 2 methods, `beforeProcessFeed()`, which runs before each page (if the feed is not paginated, then there’s only one page), and `getFeedSettings()`, which runs before each batch
- `Processing X elements finished in <number>s` => it looks like this was a bit buggy before for paginated feeds; it reported the total number of processed items but only really measured the time of the past page (fixed now)
- it looks like the logs were always a bit wonky for the paginated feeds; they were always nesting one of the processed elements under `Finished preparing for feed processing.` because the `$stepKey` was not cleared as expected (fixed now)


### Related issues
#1584 