### PR TITLE
Fixed a bug where variants would not save

### DIFF
--- a/docs/.vitepress/utils.js
+++ b/docs/.vitepress/utils.js
@@ -7,7 +7,7 @@ function renderInlineCode(tokens, idx, options, env, renderer) {
   var token = tokens[idx];
 
   return `<code v-pre ${renderer.renderAttrs(token)}>${escapeHtml(
-    tokens[idx].content,
+    tokens[idx].content
   )}</code>`;
 }
 

--- a/src/elements/CommerceProduct.php
+++ b/src/elements/CommerceProduct.php
@@ -275,7 +275,7 @@ class CommerceProduct extends Element
         $this->beforeSave($element, $settings);
 
         if ($this->element->getIsDraft()) {
-            $this->element->setDirtyAttributes(['variants']);
+            $this->element->markAsDirty();
             $this->element = Craft::$app->getDrafts()->applyDraft($this->element);
             $this->element->propagateAll = true;
         }
@@ -548,7 +548,7 @@ class CommerceProduct extends Element
             // Create a new variant, or find an existing one to edit
             if (!isset($variants[$sku])) {
                 $variants[$sku] = new VariantElement();
-                $variants[$sku]->product = $element;
+                $variants[$sku]->setOwner($element);
             }
 
             // We are going to handle stock after the product and variants save

--- a/src/fields/GoogleMaps.php
+++ b/src/fields/GoogleMaps.php
@@ -3,7 +3,6 @@
 namespace craft\feedme\fields;
 
 use Cake\Utility\Hash;
-use Craft;
 use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
 use craft\feedme\helpers\DataHelper;

--- a/src/web/assets/feedme/src/js/feed-me.js
+++ b/src/web/assets/feedme/src/js/feed-me.js
@@ -23,7 +23,7 @@ $(function () {
 
   // Change the import strategy for Users
   var $disableLabel = $(
-    'input[name="duplicateHandle[]"][value="disable"]',
+    'input[name="duplicateHandle[]"][value="disable"]'
   ).next('label');
   var originalDisableLabel = $disableLabel.text();
   var $disableInstructions = $disableLabel.siblings('.instructions');
@@ -39,10 +39,7 @@ $(function () {
     if (value === 'craft-elements-User') {
       $disableLabel.text(Craft.t('feed-me', 'Suspend missing users'));
       $disableInstructions.text(
-        Craft.t(
-          'feed-me',
-          'Suspends any users that are missing from the feed.',
-        ),
+        Craft.t('feed-me', 'Suspends any users that are missing from the feed.')
       );
     } else {
       $disableLabel.text(originalDisableLabel);
@@ -121,7 +118,7 @@ $(function () {
   // for categories and entries - only show "create if they do not exist" if matching done by "title"
   // for users - only show "create if they do not exist" if matching done by "email"
   $(
-    '.categories-field-match select, .entries-field-match select, .users-field-match select',
+    '.categories-field-match select, .entries-field-match select, .users-field-match select'
   ).on('change', function (e) {
     var match = 'title';
     var $selectParent = $(this).parent();
@@ -229,7 +226,7 @@ $(function () {
       });
 
       $container.find('select').html(newOptions);
-    },
+    }
   );
 
   $('.field-extra-settings .element-group-section select').trigger('change');

--- a/src/web/assets/feedme/src/lib/selectize.js
+++ b/src/web/assets/feedme/src/lib/selectize.js
@@ -655,7 +655,7 @@
     module.exports = factory(
       require('jquery'),
       require('sifter'),
-      require('microplugin'),
+      require('microplugin')
     );
   } else {
     root.Selectize = factory(root.jQuery, root.Sifter, root.MicroPlugin);
@@ -722,7 +722,7 @@
       for (var i = 0; i < this._events[event].length; i++) {
         this._events[event][i].apply(
           this,
-          Array.prototype.slice.call(arguments, 1),
+          Array.prototype.slice.call(arguments, 1)
         );
       }
     },
@@ -1288,7 +1288,7 @@
       if (!self.settings.splitOn && self.settings.delimiter) {
         var delimiterEscaped = self.settings.delimiter.replace(
           /[-\/\\^$*+?.()|[\]{}]/g,
-          '\\$&',
+          '\\$&'
         );
         self.settings.splitOn = new RegExp('\\s*' + delimiterEscaped + '+\\s*');
       }
@@ -1392,7 +1392,7 @@
           if (self.isOpen) {
             self.positionDropdown.apply(self, arguments);
           }
-        },
+        }
       );
       $window.on('mousemove' + eventNS, function () {
         self.ignoreHover = false;
@@ -1593,7 +1593,7 @@
         if (self.settings.splitOn) {
           setTimeout(function () {
             var splitInput = $.trim(self.$control_input.val() || '').split(
-              self.settings.splitOn,
+              self.settings.splitOn
             );
             for (var i = 0, n = splitInput.length; i < n; i++) {
               self.createItem(splitInput[i]);
@@ -2089,14 +2089,14 @@
             .stop()
             .animate(
               {scrollTop: scroll_bottom},
-              animate ? self.settings.scrollDuration : 0,
+              animate ? self.settings.scrollDuration : 0
             );
         } else if (y < scroll) {
           self.$dropdown_content
             .stop()
             .animate(
               {scrollTop: scroll_top},
-              animate ? self.settings.scrollDuration : 0,
+              animate ? self.settings.scrollDuration : 0
             );
         }
       }
@@ -2110,7 +2110,7 @@
       if (self.settings.mode === 'single') return;
 
       self.$activeItems = Array.prototype.slice.apply(
-        self.$control.children(':not(input)').addClass('active'),
+        self.$control.children(':not(input)').addClass('active')
       );
       if (self.$activeItems.length) {
         self.hideInput();
@@ -2227,7 +2227,7 @@
         calculateScore = self.settings.score.apply(this, [query]);
         if (typeof calculateScore !== 'function') {
           throw new Error(
-            'Selectize "score" setting must be a function that returns a function',
+            'Selectize "score" setting must be a function that returns a function'
           );
         }
       }
@@ -2237,7 +2237,7 @@
         self.lastQuery = query;
         result = self.sifter.search(
           query,
-          $.extend(options, {score: calculateScore}),
+          $.extend(options, {score: calculateScore})
         );
         self.currentResults = result;
       } else {
@@ -2345,8 +2345,8 @@
               'optgroup',
               $.extend({}, self.optgroups[optgroup], {
                 html: html_children,
-              }),
-            ),
+              })
+            )
           );
         } else {
           html.push(groups[optgroup].join(''));
@@ -2627,7 +2627,7 @@
     getOption: function (value) {
       return this.getElementWithValue(
         value,
-        this.$dropdown_content.find('[data-selectable]'),
+        this.$dropdown_content.find('[data-selectable]')
       );
     },
 
@@ -2947,7 +2947,7 @@
               escape_html(self.items[i]) +
               '" selected="selected">' +
               escape_html(label) +
-              '</option>',
+              '</option>'
           );
         }
         if (!options.length && !this.$input.attr('multiple')) {
@@ -3112,7 +3112,7 @@
 
       if (self.$activeItems.length) {
         $tail = self.$control.children(
-          '.active:' + (direction > 0 ? 'last' : 'first'),
+          '.active:' + (direction > 0 ? 'last' : 'first')
         );
         caret = self.$control.children(':not(input)').index($tail);
         if (direction > 0) {
@@ -3393,13 +3393,13 @@
         id = data[self.settings.optgroupValueField] || '';
         html = html.replace(
           regex_tag,
-          '<$1 data-group="' + escape_replace(escape_html(id)) + '"',
+          '<$1 data-group="' + escape_replace(escape_html(id)) + '"'
         );
       }
       if (templateName === 'option' || templateName === 'item') {
         html = html.replace(
           regex_tag,
-          '<$1 data-value="' + escape_replace(escape_html(value || '')) + '"',
+          '<$1 data-value="' + escape_replace(escape_html(value || '')) + '"'
         );
       }
 
@@ -3687,7 +3687,7 @@
 
       instance = new Selectize(
         $input,
-        $.extend(true, {}, defaults, settings_element, settings_user),
+        $.extend(true, {}, defaults, settings_element, settings_user)
       );
     });
   };
@@ -3781,7 +3781,7 @@
           );
         },
       },
-      options,
+      options
     );
 
     self.setup = (function () {
@@ -3802,7 +3802,7 @@
         equalizeWidth: true,
         equalizeHeight: true,
       },
-      options,
+      options
     );
 
     this.getAdjacentOption = function ($option, direction) {
@@ -3903,7 +3903,7 @@
         className: 'remove',
         append: true,
       },
-      options,
+      options
     );
 
     var self = this;

--- a/src/web/assets/feedme/src/scss/_font-awesome.scss
+++ b/src/web/assets/feedme/src/scss/_font-awesome.scss
@@ -4752,8 +4752,7 @@ readers do not read off random characters that represent icons */
   font-style: normal;
   font-weight: 400;
   src: url('../fonts/fa-regular-400.eot');
-  src:
-    url('../fonts/fa-regular-400.eot?#iefix') format('embedded-opentype'),
+  src: url('../fonts/fa-regular-400.eot?#iefix') format('embedded-opentype'),
     url('../fonts/fa-regular-400.woff2') format('woff2'),
     url('../fonts/fa-regular-400.woff') format('woff'),
     url('../fonts/fa-regular-400.ttf') format('truetype'),
@@ -4774,8 +4773,7 @@ readers do not read off random characters that represent icons */
   font-style: normal;
   font-weight: 900;
   src: url('../fonts/fa-solid-900.eot');
-  src:
-    url('../fonts/fa-solid-900.eot?#iefix') format('embedded-opentype'),
+  src: url('../fonts/fa-solid-900.eot?#iefix') format('embedded-opentype'),
     url('../fonts/fa-solid-900.woff2') format('woff2'),
     url('../fonts/fa-solid-900.woff') format('woff'),
     url('../fonts/fa-solid-900.ttf') format('truetype'),

--- a/src/web/assets/feedme/src/scss/feed-me.css
+++ b/src/web/assets/feedme/src/scss/feed-me.css
@@ -4751,8 +4751,7 @@ readers do not read off random characters that represent icons */
   font-style: normal;
   font-weight: 400;
   src: url('../fonts/fa-regular-400.eot');
-  src:
-    url('../fonts/fa-regular-400.eot?#iefix') format('embedded-opentype'),
+  src: url('../fonts/fa-regular-400.eot?#iefix') format('embedded-opentype'),
     url('../fonts/fa-regular-400.woff2') format('woff2'),
     url('../fonts/fa-regular-400.woff') format('woff'),
     url('../fonts/fa-regular-400.ttf') format('truetype'),
@@ -4772,8 +4771,7 @@ readers do not read off random characters that represent icons */
   font-style: normal;
   font-weight: 900;
   src: url('../fonts/fa-solid-900.eot');
-  src:
-    url('../fonts/fa-solid-900.eot?#iefix') format('embedded-opentype'),
+  src: url('../fonts/fa-solid-900.eot?#iefix') format('embedded-opentype'),
     url('../fonts/fa-solid-900.woff2') format('woff2'),
     url('../fonts/fa-solid-900.woff') format('woff'),
     url('../fonts/fa-solid-900.ttf') format('truetype'),
@@ -4889,9 +4887,7 @@ body.ltr .table-feed-me .thin.action {
   position: relative;
   display: inline-block;
   background-image: linear-gradient(#fff, #fafafa);
-  box-shadow:
-    inset 0 0 0 1px rgba(0, 0, 0, 0.1),
-    0 0 0 1px rgba(0, 0, 0, 0.025),
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.025),
     0 1px 1px rgba(0, 0, 0, 0.1);
 }
 .feedme-mapping .select:after {

--- a/src/web/assets/feedme/src/scss/feed-me.scss
+++ b/src/web/assets/feedme/src/scss/feed-me.scss
@@ -143,9 +143,7 @@ body.ltr .table-feed-me .thin.action {
   position: relative;
   display: inline-block;
   background-image: linear-gradient(#fff, #fafafa);
-  box-shadow:
-    inset 0 0 0 1px rgba(0, 0, 0, 0.1),
-    0 0 0 1px rgba(0, 0, 0, 0.025),
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.025),
     0 1px 1px rgba(0, 0, 0, 0.1);
 
   &:after {


### PR DESCRIPTION
### Description

Fixed a bug where the nested variant element manager used different attribute names (`allVariants` & `variants`) across different versions of 5.x 

Setting as 'all dirty' ensures it saves the variants in the nested element manager regardless of the attribute name used.