### PR TITLE
if user exists, don't create a new one

### DIFF
--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -324,6 +324,7 @@ class Entry extends Element
 
         $matchedIds = null;
         foreach ($values as $value) {
+            $hasMatch = false;
             if ($match === 'fullName') {
                 $element = UserElement::findOne(['search' => $value, 'status' => null]);
             } else {
@@ -336,11 +337,12 @@ class Entry extends Element
             }
 
             if ($element) {
+                $hasMatch = true;
                 $matchedIds[] = $element->id;
             }
 
             // Check if we should create the element. But only if email is provided (for the moment)
-            if ($create && $match === 'email') {
+            if (!$hasMatch && $create && $match === 'email') {
                 $element = new UserElement();
                 $element->username = $value;
                 $element->email = $value;


### PR DESCRIPTION
### Description
This fixes an issue where if you were importing Entry Authors (mapped by email, with “Create users if they do not exist” checked), the new inactive user was created regardless of whether a user with this email address already existed.


### Related issues
#1599 
