### PR TITLE
only assign default values if we have the block field info

### DIFF
--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -97,16 +97,16 @@ class Matrix extends Field implements FieldInterface
                 } else {
                     $fieldData[$key] = $parsedValue;
                 }
-            }
 
-            foreach ($blocks as $blockHandle => $fields) {
-                foreach ($fields['fields'] as $fieldHandle => $fieldInfo) {
-                    $node = Hash::get($fieldInfo, 'node');
-                    if ($node === 'usedefault') {
-                        $key = $this->_getBlockKey($nodePathSegments, $blockHandle, $fieldHandle);
+                foreach ($blocks as $blockHandle => $fields) {
+                    foreach ($fields['fields'] as $fieldHandle => $fieldInfo) {
+                        $node = Hash::get($fieldInfo, 'node');
+                        if ($node === 'usedefault') {
+                            $key = $this->_getBlockKey($nodePathSegments, $blockHandle, $fieldHandle);
 
-                        $parsedValue = DataHelper::fetchSimpleValue($this->feedData, $fieldInfo);
-                        $fieldData[$key] = $parsedValue;
+                            $parsedValue = DataHelper::fetchSimpleValue($this->feedData, $fieldInfo);
+                            $fieldData[$key] = $parsedValue;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Description
When importing into a Matrix field and “Use default value” is used for any of its subfields, if you also have at least one more arrayable value in the feed that contains more items than the number of blocks/entries that should be imported into the matrix field, extra blocks/entries were being created (using that default value).

**Steps to reproduce:**
- CMS v4 or v5 installation with Feed Me installed
- create a matrix field with at least one block and at least 2 fields in the block (can be two plain text fields, `plainText`, `secondPlainText`)
- create a section that uses this matrix field
- create a json feed (example data below) that imports to that section:
    - strategy: create, update
    - primary element: entries
    - map the title to `title`
    - map matrix > plainText to `myMatrix/MatrixBlock/plainText1`
    - map matrix > secondPlainText to `Use default value`, default value: `my default text`
- save and run the feed
- in control panel, go to the edit page for `my entry 1` and note that it contains 3 blocks/entries in the matrix field

```
{
  "entries": [
    {
      "title": "my entry 1",
      "myMatrix": {
        "MatrixBlock": [
          {
            "plainText1": "text1"
          },
          {
            "plainText1": "text2"
          }
        ]
      },
      "myArray1": ["one", "two", "three"]
    }
  ]
}
```

### Related issues
#1607 
