### PR TITLE
fix comparing content for a "simple" field that already has an empty value

### DIFF
--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -454,6 +454,17 @@ class DataHelper
             return true;
         }
 
+        // and if everything else failed, we might have a situation where the $fields[$key] value is empty (null)
+        // in which case Hash::extract will return an empty array and therefore Hash::check fill return false
+        // and the values won't actually be compared
+        // @see https://github.com/craftcms/feed-me/issues/1615
+        if (
+            array_key_exists($key, $fields) &&
+            (!is_numeric($firstValue) && !is_bool($firstValue) && empty($firstValue)) &&
+            (!is_numeric($secondValue) && !is_bool($secondValue) && empty($secondValue))) {
+            return true;
+        }
+
         // Didn't match
         return false;
     }


### PR DESCRIPTION
### Description
If you’re importing into a feed with `setEmptyValues` turned on, `compareContent` set to true (default), you have an existing element with a field that’s already empty, and you’re importing an empty value into that field, the content comparison was incorrectly reporting that the content has changed.

This happened because the `Hash::check` will always return `false` if the key exists but the value is `null`, causing the content to never actually get compared. 

(`Hash::extract` will [return an empty array](https://github.com/cakephp/cakephp/blob/3.9.4/src/Utility/Hash.php#L142) causing `Hash::check` to [return false](https://github.com/cakephp/cakephp/blob/3.9.4/src/Utility/Hash.php#L637).)


### Related issues
#1615
