### PR TITLE
additional safeguard in case matrix field has no blocks

### DIFF
--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -53,6 +53,10 @@ class Matrix extends Field implements FieldInterface
 
         $blocks = Hash::get($this->fieldInfo, 'blocks');
 
+        if ($blocks === null) {
+            return null;
+        }
+
         // Before we do anything, we need to extract the data from our feed and normalise it. This is especially
         // complex due to sub-fields, which each can be a variety of fields and formats, compounded by multiple or
         // Matrix blocks - we don't know! We also need to be careful of the order data is in the feed to be


### PR DESCRIPTION
### Description
If no blocks were identified for a matrix field, return `null` straight away.

The error described in the [related issue](https://github.com/craftcms/feed-me/issues/1617) shouldn’t actually get triggered in v5 (for Craft 4), but this check won’t do any harm, so targeting v5 for consistency between versions.


### Related issues
#1617 
