### PR TITLE
Bugfix/1618 comparing content and arrays

### DIFF
--- a/src/events/CompareContentEvent.php
+++ b/src/events/CompareContentEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace craft\feedme\events;
+
+use craft\base\ElementInterface;
+use yii\base\Event;
+
+/**
+ * Compare content event class.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.12.0
+ */
+class CompareContentEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var array
+     */
+    public array $content;
+
+    /**
+     * @var ElementInterface
+     */
+    public ElementInterface $element;
+
+    /**
+     * @var string
+     */
+    public string $handle;
+
+    /**
+     * @var mixed
+     */
+    public mixed $existingValue;
+
+    /**
+     * @var mixed
+     */
+    public mixed $newValue;
+}

--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -264,6 +264,7 @@ class DataHelper
         foreach ($content as $key => $newValue) {
             $existingValue = Hash::get($fields, $key);
 
+            [$existingValue, $newValue] = Plugin::$plugin->process->onCompareContent($content, $element, $key, $existingValue, $newValue);
 
             // Check for simple fields first
             if (self::_compareSimpleValues($fields, $key, $existingValue, $newValue)) {

--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -264,13 +264,6 @@ class DataHelper
         foreach ($content as $key => $newValue) {
             $existingValue = Hash::get($fields, $key);
 
-            [$existingValue, $newValue] = self::prepDatesForComparison($existingValue, $newValue);
-
-            // If array key & values are already within the existing array
-            if (is_array($newValue) && is_array($existingValue) && Hash::contains($existingValue,$newValue)) {
-                unset($trackedChanges[$key]);
-                continue;
-            }
 
             // Check for simple fields first
             if (self::_compareSimpleValues($fields, $key, $existingValue, $newValue)) {

--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -32,6 +32,11 @@ class Process extends Component
     public const EVENT_STEP_BEFORE_ELEMENT_SAVE = 'onStepBeforeElementSave';
     public const EVENT_STEP_AFTER_ELEMENT_SAVE = 'onStepElementSave';
     public const EVENT_AFTER_PROCESS_FEED = 'onAfterProcessFeed';
+
+    /**
+     * @event CompareContentEvent The event that is triggered before content is compared to check for changes.
+     * @since 5.12.0
+     */
     public const EVENT_COMPARE_CONTENT = 'onCompareContent';
 
 

--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -636,18 +636,23 @@ class Process extends Component
     {
         [$existingValue, $newValue] = DataHelper::prepDatesForComparison($existingValue, $newValue);
 
-        $event = new CompareContentEvent([
-            'content' => $content,
-            'element' => $element,
-            'handle' => $key,
-            'existingValue' => $existingValue,
-            'newValue' => $newValue,
-        ]);
+        if ($this->hasEventHandlers(self::EVENT_COMPARE_CONTENT)) {
+            $event = new CompareContentEvent([
+                'content' => $content,
+                'element' => $element,
+                'handle' => $key,
+                'existingValue' => $existingValue,
+                'newValue' => $newValue,
+            ]);
 
-        $this->trigger(self::EVENT_COMPARE_CONTENT, $event);
+            $this->trigger(self::EVENT_COMPARE_CONTENT, $event);
+
+            // Allow event to overwrite existing and new value to be used for comparison
+            return [$event->existingValue, $event->newValue];
+        }
 
         // Allow event to overwrite existing and new value to be used for comparison
-        return [$event->existingValue, $event->newValue];
+        return [$existingValue, $newValue];
     }
 
 

--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -5,9 +5,11 @@ namespace craft\feedme\services;
 use Cake\Utility\Hash;
 use Craft;
 use craft\base\Component;
+use craft\base\ElementInterface as CraftElementInterface;
 use craft\elements\User;
 use craft\errors\ShellCommandException;
 use craft\feedme\base\ElementInterface;
+use craft\feedme\events\CompareContentEvent;
 use craft\feedme\events\FeedProcessEvent;
 use craft\feedme\helpers\DataHelper;
 use craft\feedme\helpers\DuplicateHelper;
@@ -30,6 +32,7 @@ class Process extends Component
     public const EVENT_STEP_BEFORE_ELEMENT_SAVE = 'onStepBeforeElementSave';
     public const EVENT_STEP_AFTER_ELEMENT_SAVE = 'onStepElementSave';
     public const EVENT_AFTER_PROCESS_FEED = 'onAfterProcessFeed';
+    public const EVENT_COMPARE_CONTENT = 'onCompareContent';
 
 
     // Properties
@@ -616,6 +619,35 @@ class Process extends Component
         } else {
             $this->afterProcessFeed($feedSettings, $feed, $processedElementIds);
         }
+    }
+
+    /**
+     * Prepare data for content comparison and allow plugins to do so via an event.
+     *
+     * @param array $content
+     * @param CraftElementInterface $element
+     * @param string $key
+     * @param mixed $existingValue
+     * @param mixed $newValue
+     * @return mixed
+     * @since 5.12.0
+     */
+    public function onCompareContent(array $content, CraftElementInterface $element, string $key, mixed $existingValue, mixed $newValue): mixed
+    {
+        [$existingValue, $newValue] = DataHelper::prepDatesForComparison($existingValue, $newValue);
+
+        $event = new CompareContentEvent([
+            'content' => $content,
+            'element' => $element,
+            'handle' => $key,
+            'existingValue' => $existingValue,
+            'newValue' => $newValue,
+        ]);
+
+        $this->trigger(self::EVENT_COMPARE_CONTENT, $event);
+
+        // Allow event to overwrite existing and new value to be used for comparison
+        return [$event->existingValue, $event->newValue];
     }
 
 


### PR DESCRIPTION
### Description
We previously approved [this PR](https://github.com/craftcms/feed-me/pull/1370). While it worked as expected in the majority of cases, it’ll break content comparison if the only change for a given element is that an element is removed from a relation field. 

For example, you have an Entries field that already has entries with IDs of 3,4,5, and you run an import that is supposed to change its content to entries with IDs of 3,4, so you effectively remove the entry with ID 5 from that field.
In this case, the code from that PR caused the content comparison to falsely report that the content is unchanged and the changes were not saved. (If anything else changed too, then the content was saved, which is why it wasn’t noticed for a while.)

To fix this issue, I had to remove the bit of code added by PR #1370. To make the content comparison work in cases that it was supposed to help with, I added:
- `Process::EVENT_COMPARE_CONTENT`
- `CompareContentEvent`
- `Process->onCompareContent()` method

Plugins and developers can use `Process::EVENT_COMPARE_CONTENT` to prepare/manipulate the data before the content comparison is done.

For example, in the case of Google Maps plugin (as per #1370), the following code would help prevent unnecessary address updates:
```
Event::on(
    Process::class,
    Process::EVENT_COMPARE_CONTENT,
    function (CompareContentEvent $event) {
        $field = Craft::$app->getFields()->getFieldByHandle($event->handle);
        if ($field && $field instanceof \doublesecretagency\googlemaps\fields\AddressField) {
            if (is_array($event->newValue) && is_array($event->existingValue) && Hash::contains($event->existingValue, $event->newValue)) {
                $event->newValue = $event->existingValue;
            }
        }
    }
);
```

Raising as a draft as I want to do a bit more testing.

### Related issues
#1618, #1577
