### PR TITLE
only call `EVENT_BEFORE_PROCESS_FEED` once per page, as before

### DIFF
--- a/src/queue/jobs/FeedImport.php
+++ b/src/queue/jobs/FeedImport.php
@@ -161,7 +161,6 @@ class FeedImport extends BaseBatchedJob implements RetryableJobInterface
             $data = $event->feedData;
 
             $processService->beforeProcessFeed($this->feed, $data);
-
         }
 
         if (!$this->startTime) {

--- a/src/queue/jobs/FeedImport.php
+++ b/src/queue/jobs/FeedImport.php
@@ -114,21 +114,6 @@ class FeedImport extends BaseBatchedJob implements RetryableJobInterface
 
         $data = array_values($data);
 
-        // Fire an 'onBeforeProcessFeed' event
-        $event = new FeedProcessEvent([
-            'feed' => $this->feed,
-            'feedData' => $data,
-        ]);
-
-        Plugin::$plugin->process->trigger(Process::EVENT_BEFORE_PROCESS_FEED, $event);
-
-        if (!$event->isValid) {
-            return new DataBatcher([]);
-        }
-
-        // Allow event to modify the feed data
-        $data = $event->feedData;
-
         return new DataBatcher($data);
     }
 
@@ -158,8 +143,25 @@ class FeedImport extends BaseBatchedJob implements RetryableJobInterface
     public function execute($queue): void
     {
         $processService = Plugin::$plugin->getProcess();
+        $data = (array)$this->data();
         if ($this->itemOffset == 0) {
-            $processService->beforeProcessFeed($this->feed, (array)$this->data());
+            // Fire an 'onBeforeProcessFeed' event
+            $event = new FeedProcessEvent([
+                'feed' => $this->feed,
+                'feedData' => $data,
+            ]);
+
+            Plugin::$plugin->process->trigger(Process::EVENT_BEFORE_PROCESS_FEED, $event);
+
+            if (!$event->isValid) {
+                return;
+            }
+
+            // Allow event to modify the feed data
+            $data = $event->feedData;
+
+            $processService->beforeProcessFeed($this->feed, $data);
+
         }
 
         if (!$this->startTime) {
@@ -167,7 +169,7 @@ class FeedImport extends BaseBatchedJob implements RetryableJobInterface
         }
 
         if (empty($this->_feedSettings)) {
-            $this->_feedSettings = $processService->getFeedSettings($this->feed, (array)$this->data());
+            $this->_feedSettings = $processService->getFeedSettings($this->feed, $data);
         }
 
         parent::execute($queue);


### PR DESCRIPTION
### Description
Fixes a bug where `EVENT_BEFORE_PROCESS_FEED` was called once per batch and not once per page as intended and as it was before we introduced the `BaseBatchedJob` to Feed Me.


- `Process::EVENT_BEFORE_PROCESS_FEED` is called once per page (if there’s no pagination, then there’s one page, so it’s called once) - that was also the case before we implemented `BaseBatchedJob`
- `Process::EVENT_AFTER_PROCESS_FEED` is called once for the entire import (regardless of pagination)
- `Process::EVENT_STEP_BEFORE_PARSE_CONTENT` is called for every primary element that was found in the feed’s data
- `DataTypes::EVENT_BEFORE_FETCH_FEED`, `DataTypes::EVENT_AFTER_FETCH_FEED`, `DataTypes::EVENT_AFTER_PARSE_FEED` are called whenever feed data needs to be retrieved, which means as minimum once per batch


### Related issues
#1619 
