### PR TITLE
special handling for "or" and "and" values

### DIFF
--- a/src/fields/CalendarEvents.php
+++ b/src/fields/CalendarEvents.php
@@ -8,7 +8,6 @@ use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
 use craft\feedme\helpers\DataHelper;
 use craft\feedme\Plugin;
-use craft\helpers\Db;
 use craft\helpers\Json;
 use Solspace\Calendar\Elements\Event as EventElement;
 

--- a/src/fields/CalendarEvents.php
+++ b/src/fields/CalendarEvents.php
@@ -125,7 +125,8 @@ class CalendarEvents extends Field implements FieldInterface
             $criteria['status'] = null;
             $criteria['typeId'] = $typeIds;
             $criteria['limit'] = $limit;
-            $criteria[$match] = Db::escapeParam($dataValue);
+            // prep the $dataValue for matching
+            $criteria[$match] = DataHelper::prepValueForElementMatch($dataValue);
 
             Craft::configure($query, $criteria);
 

--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -153,7 +153,8 @@ class Categories extends Field implements FieldInterface
 
             $criteria['status'] = null;
             $criteria['limit'] = $limit;
-            $criteria[$match] = Db::escapeParam($dataValue);
+            // prep the $dataValue for matching
+            $criteria[$match] = DataHelper::prepValueForElementMatch($dataValue);
 
             Craft::configure($query, $criteria);
 

--- a/src/fields/CommerceProducts.php
+++ b/src/fields/CommerceProducts.php
@@ -129,7 +129,8 @@ class CommerceProducts extends Field implements FieldInterface
             $criteria['status'] = null;
             $criteria['typeId'] = $typeIds;
             $criteria['limit'] = $limit;
-            $criteria[$match] = Db::escapeParam($dataValue);
+            // prep the $dataValue for matching
+            $criteria[$match] = DataHelper::prepValueForElementMatch($dataValue);
 
             Craft::configure($query, $criteria);
 

--- a/src/fields/CommerceVariants.php
+++ b/src/fields/CommerceVariants.php
@@ -129,7 +129,8 @@ class CommerceVariants extends Field implements FieldInterface
             $criteria['status'] = null;
             $criteria['typeId'] = $typeIds;
             $criteria['limit'] = $limit;
-            $criteria[$match] = Db::escapeParam($dataValue);
+            // prep the $dataValue for matching
+            $criteria[$match] = DataHelper::prepValueForElementMatch($dataValue);
 
             Craft::configure($query, $criteria);
 

--- a/src/fields/CommerceVariants.php
+++ b/src/fields/CommerceVariants.php
@@ -10,7 +10,6 @@ use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
 use craft\feedme\helpers\DataHelper;
 use craft\feedme\Plugin;
-use craft\helpers\Db;
 use craft\helpers\Json;
 
 /**

--- a/src/fields/DigitalProducts.php
+++ b/src/fields/DigitalProducts.php
@@ -9,7 +9,6 @@ use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
 use craft\feedme\helpers\DataHelper;
 use craft\feedme\Plugin;
-use craft\helpers\Db;
 use craft\helpers\Json;
 
 /**

--- a/src/fields/DigitalProducts.php
+++ b/src/fields/DigitalProducts.php
@@ -130,7 +130,8 @@ class DigitalProducts extends Field implements FieldInterface
             $criteria['status'] = null;
             $criteria['typeId'] = $typeIds;
             $criteria['limit'] = $limit;
-            $criteria[$match] = Db::escapeParam($dataValue);
+            // prep the $dataValue for matching
+            $criteria[$match] = DataHelper::prepValueForElementMatch($dataValue);
 
             Craft::configure($query, $criteria);
 

--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -169,7 +169,8 @@ class Entries extends Field implements FieldInterface
 
             $criteria['status'] = null;
             $criteria['limit'] = $limit;
-            $criteria[$match] = Db::escapeParam($dataValue);
+            // prep the $dataValue for matching
+            $criteria[$match] = DataHelper::prepValueForElementMatch($dataValue);
 
             Craft::configure($query, $criteria);
 

--- a/src/fields/Tags.php
+++ b/src/fields/Tags.php
@@ -127,7 +127,8 @@ class Tags extends Field implements FieldInterface
             $criteria['status'] = null;
             $criteria['groupId'] = $groupId;
             $criteria['limit'] = $limit;
-            $criteria[$match] = Db::escapeParam($dataValue);
+            // prep the $dataValue for matching
+            $criteria[$match] = DataHelper::prepValueForElementMatch($dataValue);
 
             Craft::configure($query, $criteria);
 

--- a/src/fields/Users.php
+++ b/src/fields/Users.php
@@ -155,7 +155,8 @@ class Users extends Field implements FieldInterface
             $ids = [];
             $criteria['status'] = null;
             $criteria['limit'] = $limit;
-            $criteria[$match] = Db::escapeParam($dataValue);
+            // prep the $dataValue for matching
+            $criteria[$match] = DataHelper::prepValueForElementMatch($dataValue);
 
             // If the only source for the Users field is "admins" we don't have to bother with this query.
             if (!($isAdmin && empty($groupIds) && empty($customSources))) {

--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -362,6 +362,28 @@ class DataHelper
     }
 
     /**
+     * Prepares given value for finding an element by it.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    public static function prepValueForElementMatch(mixed $value): mixed
+    {
+        $value = Db::escapeParam($value);
+
+        // ensure that if the value is exactly "or" or "and" (case-insensitive), we escape it too
+        $operators = ['or', 'and'];
+        foreach ($operators as $operator) {
+            if (strcasecmp($value, $operator) === 0) {
+                $value = "=$value";
+                break;
+            }
+        }
+
+        return $value;
+    }
+
+    /**
      * @param $array1
      * @param $array2
      * @return bool|array


### PR DESCRIPTION
### Description
In addition to [escaping values](https://github.com/craftcms/feed-me/pull/1551) used to find matching elements, we also need a way to allow matching in cases where the value is exactly “or” or “and”. 

At the moment, if you have, e.g. a category with a title of “OR” you won’t be able to match it - instead, all categories will be returned. 

If you were querying by those in twig or php, you’d have to do something like `title('=OR')`, so I added a method that will do just that in Feed Me. 

Note that Feed Me v5 (for cms v4) is not affected as the matching is done slightly differently there.



### Related issues
#1624 
