### PR TITLE
only ignore the block if title and slug are not being set either

### DIFF
--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -226,7 +226,7 @@ class Matrix extends Field implements FieldInterface
         $index = 1;
         $resultBlocks = [];
         foreach ($expanded as $blockData) {
-            // if all the fields are empty and setEmptyValues is off, ignore the block
+            // if all the fields are empty and setEmptyValues is off and there's no title or slug being set, ignore the block
             if (
                 !empty(array_filter(
                     $blockData['fields'],
@@ -236,7 +236,8 @@ class Matrix extends Field implements FieldInterface
                         is_bool($value) ||
                         is_numeric($value)
                     )
-                ))
+                )) ||
+                (!empty($blockData['title']) || !empty($blockData['slug']))
             ) {
                 $resultBlocks['new' . $index++] = $blockData;
             }


### PR DESCRIPTION
### Description
Fixes a bug where importing only a title for a matrix entry (formerly block) would result in that nested entry not being imported.

v5 (for cms v4) is not affected as there are no native titles (or slugs) for matrix blocks there.

### Related issues
#1626 
