### PR TITLE
Bugfix: Fix import into entry field from an array

### DIFF
--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -103,7 +103,7 @@ class DataHelper
                     }
                     $value = array_merge($value, $delimitedValues);
                 } else {
-                    $value[] = $nodeValue;
+                    $value = $nodeValue;
                 }
             }
         }


### PR DESCRIPTION
### Description
This adjustment fixes a simple bug:
If you want to import entries from an array (as in the example in the documentation https://docs.craftcms.com/feed-me/v6/content-mapping/field-types.html#entries), an error occurs:

TypeError
craft\helpers\Db::escapeParam(): Argument #1 ($value) must be of type string, array given, called in /var/www/html/vendor/craftcms/feed-me/src/fields/Entries.php on line 172

This error occurs because the parsed values are stored in a subarray in the fetchArrayValue method.

### Related issues

