### PR TITLE
Archive tables before installing

### DIFF
--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -11,7 +11,6 @@ class Install extends Migration
 
     public function safeUp(): bool
     {
-        $this->archiveTables();
         $this->createTables();
 
         return true;
@@ -29,6 +28,7 @@ class Install extends Migration
 
     protected function createTables(): void
     {
+        $this->archiveTableIfExists('{{%feedme_feeds}}');
         $this->createTable('{{%feedme_feeds}}', [
             'id' => $this->primaryKey(),
             'name' => $this->string()->notNull(),
@@ -55,6 +55,7 @@ class Install extends Migration
         ]);
 
         // @see \craft\feedme\migrations\m240611_134740_create_logs_table
+        $this->archiveTableIfExists('{{%feedme_logs}}');
         $this->createTable('{{%feedme_logs}}', [
             'id' => $this->bigPrimaryKey(),
             'level' => $this->integer(),
@@ -66,12 +67,6 @@ class Install extends Migration
 
         $this->createIndex('idx_log_level', '{{%feedme_logs}}', 'level');
         $this->createIndex('idx_log_category', '{{%feedme_logs}}', 'category');
-    }
-
-    protected function archiveTables(): void
-    {
-        $this->archiveTableIfExists('{{%feedme_feeds}}');
-        $this->archiveTableIfExists('{{%feedme_logs}}');
     }
 
     protected function removeTables(): void

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -11,8 +11,7 @@ class Install extends Migration
 
     public function safeUp(): bool
     {
-        $this->archiveTableIfExists('{{%feedme_feeds}}');
-        $this->archiveTableIfExists('{{%feedme_logs}}');
+        $this->archiveTables();
         $this->createTables();
 
         return true;
@@ -67,6 +66,12 @@ class Install extends Migration
 
         $this->createIndex('idx_log_level', '{{%feedme_logs}}', 'level');
         $this->createIndex('idx_log_category', '{{%feedme_logs}}', 'category');
+    }
+
+    protected function archiveTables(): void
+    {
+        $this->archiveTableIfExists('{{%feedme_feeds}}');
+        $this->archiveTableIfExists('{{%feedme_logs}}');
     }
 
     protected function removeTables(): void

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -11,7 +11,8 @@ class Install extends Migration
 
     public function safeUp(): bool
     {
-        $this->removeTables();
+        $this->archiveTableIfExists('{{%feedme_feeds}}');
+        $this->archiveTableIfExists('{{%feedme_logs}}');
         $this->createTables();
 
         return true;

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -11,6 +11,7 @@ class Install extends Migration
 
     public function safeUp(): bool
     {
+        $this->removeTables();
         $this->createTables();
 
         return true;


### PR DESCRIPTION
### Description
The following can be quite common:
- A DB dump is restored to an environment where Feedme isn't installed, but _was installed_ in the environment where the dump was captured.
- Feedme is installed locally
- Deploy initiated
- Post-deploy migrations (`craft up`) fail, because the tables already exist.

Developers should run `craft up` before deploying, which _might_ catch before deploy, but only if the local environment also has those tables.

### Related issues
https://github.com/craftcms/feed-me/issues/1639