### PR TITLE
fix: handle null formatting in date parsing

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -345,7 +345,12 @@ abstract class Element extends Component implements ElementInterface
      */
     protected function parseDateAttribute($value, $formatting): ?DateTime
     {
-        $dateValue = DateHelper::parseString($value, $formatting);
+        if (empty($formatting)) {
+            $dateValue = DateHelper::parseString($value);
+        } else {
+            $dateValue = DateHelper::parseString($value, $formatting);
+        }
+
         if ($dateValue instanceof Carbon) {
             $dateValue = $dateValue->toDateTime();
         }


### PR DESCRIPTION
## Description
Fixes #1655 

When calling `craft\feedme\services\Process->processFeed()` from CLI using JSON data exported by Craft's export button, the `$formatting` parameter can be null when not specified in `$fieldInfo`. This causes a TypeError in `DateHelper::parseString()`.

## Changes
- Added null check in `parseDateAttribute()` to default to 'auto' formatting
- Prevents TypeError when processing exported JSON data without explicit date formatting

## Testing
- [x] Tested with exported JSON data via CLI
- [x] Confirmed existing functionality remains intact