### PR TITLE
remove preexisting tables before creating new ones

### DIFF
--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -11,6 +11,9 @@ class Install extends Migration
 
     public function safeUp(): bool
     {
+        // first check if any tables already exist and if they do, remove them
+        $this->removeTables();
+        // and now create new tables
         $this->createTables();
 
         return true;


### PR DESCRIPTION
### Description
During plugin installation, remove preexisting tables before creating new ones.


### Related issues
#1639 
