### PR TITLE
show the feed name on logs tab

### DIFF
--- a/src/services/Logs.php
+++ b/src/services/Logs.php
@@ -164,10 +164,16 @@ class Logs extends Component
         $logEntries = $query->collect()->reduce(function(Collection $logs, array $row) {
             $json = Json::decodeIfJson($row['message']);
             $key = $json['key'] ?? $logs->count();
+
+            if ($json['message']) {
+                $message = $json['feed'] ? $json['feed'] . ': ' . $json['message'] : $json['message'];
+            } else {
+                $message = $json;
+            }
             $log = [
                 'type' => self::logLevelName($row['level']),
                 'date' => Db::prepareDateForDb($row['log_time']),
-                'message' => $json['message'] ?? $json,
+                'message' => $message,
                 'key' => $key,
             ];
 


### PR DESCRIPTION
### Description
In `5.6.0` and `6.2.0`, we moved to storing logs in the database by default. For each log entry, we’re storing the feed name that the message is related to, but we stopped displaying it on the Logs tab in the Control Panel.

This PR makes the feed name prefix show again on the Logs tab in the Control Panel.

Before:
<img width="1428" height="573" alt="Screenshot 2025-08-07 at 14 53 52" src="https://github.com/user-attachments/assets/fa601a59-285d-4dec-a943-a9204240e592" />

After:
<img width="1438" height="566" alt="Screenshot 2025-08-07 at 14 54 05" src="https://github.com/user-attachments/assets/b4c3c615-de54-481a-aadb-38afb8581121" />



### Related issues
#1636
