### PR TITLE
prepValueForElementMatch should account for arrays

### DIFF
--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -363,12 +363,16 @@ class DataHelper
      */
     public static function prepValueForElementMatch(mixed $value): mixed
     {
-        $value = Db::escapeParam($value);
+        if (is_array($value)) {
+            array_walk($value, fn($v) => Db::escapeParam($v));
+        } elseif (is_string($value)) {
+            $value = Db::escapeParam($value);
+        }
 
         // ensure that if the value is exactly "or" or "and" (case-insensitive), we escape it too
         $operators = ['or', 'and'];
         foreach ($operators as $operator) {
-            if (strcasecmp($value, $operator) === 0) {
+            if (is_string($value) && strcasecmp($value, $operator) === 0) {
                 $value = "=$value";
                 break;
             }


### PR DESCRIPTION
### Description
If you’re importing an array of elements into a related field and you use the Debug option, you’ll get an error. The `DataHelper::prepValueForElementMatch()` now better accounts for arrays/strings.

(This only applies to v6.)

### Related issues
#1645, #1657
