### PR TITLE
get product type id by uid

### DIFF
--- a/src/fields/CommerceVariants.php
+++ b/src/fields/CommerceVariants.php
@@ -10,6 +10,7 @@ use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
 use craft\feedme\helpers\DataHelper;
 use craft\feedme\Plugin;
+use craft\helpers\Db;
 use craft\helpers\Json;
 
 /**
@@ -83,7 +84,7 @@ class CommerceVariants extends Field implements FieldInterface
         if (is_array($sources)) {
             foreach ($sources as $source) {
                 [, $uid] = explode(':', $source);
-                $typeIds[] = $uid;
+                $typeIds[] = Db::idByUid('{{%commerce_producttypes}}', $uid);
             }
         } elseif ($sources === '*') {
             $typeIds = null;


### PR DESCRIPTION
### Description
When the Commerce Variants field has a subset of sources selected, the query should use product type IDs (not UIDs) when searching for a matching variant.


### Related issues
#1652 
