### PR TITLE
flatten data for debug view too

### DIFF
--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -619,6 +619,18 @@ class Process extends Component
             return;
         }
 
+        $data = $feedData;
+
+        foreach ($feedData as $key => $nodeData) {
+            if (!is_array($nodeData)) {
+                $nodeData = [$nodeData];
+            }
+
+            $data[$key] = Hash::flatten($nodeData, '/');
+        }
+
+        $feedData = array_values($data);
+
         $this->beforeProcessFeed($feed, $feedData);
         $feedSettings = $this->getFeedSettings($feed, $feedData);
 


### PR DESCRIPTION
### Description
When adding batched jobs to Feed Me, the data run via the “Debug” option accidentally stopped being flattened to a one-dimensional array. This caused the inconsistency described on the related issue and also caused a variation of issue #1645 for v5 (for cms v4).

I also tested how this and PR #1667 work for v6, and all works as expected.


### Related issues
#1642 
