### PR TITLE
when getting match fields for categories field, use the group layout

### DIFF
--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -253,10 +253,15 @@ class Categories extends Field implements FieldInterface
                 return FieldHelper::getAllUniqueIdFields();
             }
             // otherwise get the layout for the group selected in the field's settings
-            return array_filter(
-                FieldHelper::getElementLayoutByField($field::class, $field) ?? [],
-                fn($field) => FieldHelper::fieldCanBeUniqueId($field)
-            );
+            $group = FieldHelper::getCategorySourcesByField($field);
+            if (!$group) {
+                return FieldHelper::getAllUniqueIdFields();
+            }
+
+            $fieldLayout = Craft::$app->getFields()->getLayoutById($group->fieldLayoutId);
+            $allowedFields = $fieldLayout?->getCustomFields() ?? [];
+
+            return array_filter($allowedFields, fn($field) => FieldHelper::fieldCanBeUniqueId($field));
         }
     }
 


### PR DESCRIPTION
### Description
When getting match fields for the Categories field, we should get the field layout for the group assigned to that field and get the custom fields from it, as opposed to relying on `FieldHelper::getElementLayoutByField()`, which, as of `6.10.0`, will also return native fields.


### Related issues
#1673 
