### PR TITLE
Remove existing matrix blocks

### DIFF
--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -219,9 +219,9 @@ class Matrix extends Field implements FieldInterface
             }
         }
 
-        // if there's nothing in the prepped data, return null, as if mapping doesn't exist
+        // if there's nothing in the prepped data, return an empty array, this will remove any existing blocks
         if (empty($preppedData)) {
-            return null;
+            return [];
         }
 
         $expanded = Hash::expand($preppedData);


### PR DESCRIPTION
### Description
If prepped data is empty then this returns an empty array instead of null. 
The effect being that any existing blocks will be removed.

This is, I believe, the expected result if one wants to removed already created blocks. Otherwise there does not seem to be a way to remove blocks from the Matrix once they have been created by a previous import.


### Related issues
https://github.com/craftcms/feed-me/issues/1684
