### PR TITLE
safeguards for getting a field from layout element

### DIFF
--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -6,6 +6,9 @@ use Cake\Utility\Hash;
 use Craft;
 use craft\base\Component;
 use craft\base\ComponentInterface;
+use craft\base\FieldInterface as CraftFieldInterface;
+use craft\base\FieldLayoutElement;
+use craft\errors\FieldNotFoundException;
 use craft\errors\MissingComponentException;
 use craft\feedme\base\FieldInterface;
 use craft\feedme\events\FieldEvent;
@@ -370,5 +373,21 @@ class Fields extends Component
         ]);
         $this->trigger(self::EVENT_AFTER_PARSE_NATIVE_FIELD, $event);
         return $event->parsedValue;
+    }
+
+    /**
+     * @param FieldLayoutElement $layoutElement
+     * @return CraftFieldInterface|null
+     */
+    public function getFieldFromLayoutElement(FieldLayoutElement $layoutElement): ?CraftFieldInterface
+    {
+        try {
+            $field = $layoutElement->getField();
+        } catch (FieldNotFoundException $e) {
+            // if we can't find the field - return null
+            return null;
+        }
+
+        return $field;
     }
 }

--- a/src/templates/_includes/elements/assets/map.html
+++ b/src/templates/_includes/elements/assets/map.html
@@ -87,6 +87,7 @@
             </thead>
             <tbody>
                 {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField') or e is instance of('craft\\fieldlayoutelements\\assets\\AltField')) %}
+                    {% set fieldClass = null %}
                     {% if layoutField is instance of('craft\\fieldlayoutelements\\assets\\AltField') %}
                         {% set fieldClass = craft.feedme.fields.getRegisteredNativeField(className(layoutField)) %}
 
@@ -99,22 +100,26 @@
                             fieldClass: fieldClass,
                         } %}
                     {% else %}
-                        {% set field = layoutField.getField() %}
-                        {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
+                        {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+                        {% if field %}
+                            {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
 
-                        {% set variables = {
-                            name: field.name,
-                            handle: field.handle,
-                            feed: feed,
-                            feedData: feedData,
-                            field: field,
-                            fieldClass: fieldClass
-                        } %}
+                            {% set variables = {
+                                name: field.name,
+                                handle: field.handle,
+                                feed: feed,
+                                feedData: feedData,
+                                field: field,
+                                fieldClass: fieldClass
+                            } %}
+                        {% endif %}
                     {% endif %}
 
-                    {% set template = fieldClass.getMappingTemplate() %}
+                    {% if fieldClass %}
+                        {% set template = fieldClass.getMappingTemplate() %}
 
-                    {% include template ignore missing with variables only %}
+                        {% include template ignore missing with variables only %}
+                    {% endif %}
                 {% endfor %}
             </tbody>
         </table>
@@ -128,8 +133,10 @@
 
 {% for tab in tabs %}
     {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-        {% set field = layoutField.getField() %}
-        {% set fields = fields|merge([{ name: field.name, handle: field.handle, type: className(field) }]) %}
+        {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+        {% if field %}
+            {% set fields = fields|merge([{ name: field.name, handle: field.handle, type: className(field) }]) %}
+        {% endif %}
     {% endfor %}
 {% endfor %}
 

--- a/src/templates/_includes/elements/calendar-events/map.html
+++ b/src/templates/_includes/elements/calendar-events/map.html
@@ -201,13 +201,15 @@
             </thead>
             <tbody>
                 {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-                    {% set field = layoutField.getField() %}
-                    {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
-                    {% set template = fieldClass.getMappingTemplate() %}
+                    {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+                    {% if field %}
+                        {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
+                        {% set template = fieldClass.getMappingTemplate() %}
 
-                    {% set variables = { name: field.name, handle: field.handle, feed: feed, feedData: feedData, field: field, fieldClass: fieldClass } %}
+                        {% set variables = { name: field.name, handle: field.handle, feed: feed, feedData: feedData, field: field, fieldClass: fieldClass } %}
 
-                    {% include template ignore missing with variables only %}
+                        {% include template ignore missing with variables only %}
+                    {% endif %}
                 {% endfor %}
             </tbody>
         </table>
@@ -227,8 +229,10 @@
 
 {% for tab in tabs %}
     {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-        {% set field = layoutField.getField() %}
-        {% set uniqueFields = uniqueFields|merge([{ name: field.name, handle: field.handle, type: className(field) }]) %}
+        {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+        {% if field %}
+            {% set uniqueFields = uniqueFields|merge([{ name: field.name, handle: field.handle, type: className(field) }]) %}
+        {% endif %}
     {% endfor %}
 {% endfor %}
 

--- a/src/templates/_includes/elements/categories/map.html
+++ b/src/templates/_includes/elements/categories/map.html
@@ -91,13 +91,15 @@
             </thead>
             <tbody>
                 {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-                    {% set field = layoutField.getField() %}
-                    {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
-                    {% set template = fieldClass.getMappingTemplate() %}
+                    {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+                    {% if field %}
+                        {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
+                        {% set template = fieldClass.getMappingTemplate() %}
 
-                    {% set variables = { name: field.name, handle: field.handle, feed: feed, feedData: feedData, field: field, fieldClass: fieldClass } %}
+                        {% set variables = { name: field.name, handle: field.handle, feed: feed, feedData: feedData, field: field, fieldClass: fieldClass } %}
 
-                    {% include template ignore missing with variables only %}
+                        {% include template ignore missing with variables only %}
+                    {% endif %}
                 {% endfor %}
             </tbody>
         </table>
@@ -111,8 +113,10 @@
 
 {% for tab in tabs %}
     {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-        {% set field = layoutField.getField() %}
-        {% set fields = fields|merge([{ name: field.name, handle: field.handle, type: className(field) }]) %}
+        {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+        {% if field %}
+            {% set fields = fields|merge([{ name: field.name, handle: field.handle, type: className(field) }]) %}
+        {% endif %}
     {% endfor %}
 {% endfor %}
 

--- a/src/templates/_includes/elements/commerce-products/map.html
+++ b/src/templates/_includes/elements/commerce-products/map.html
@@ -258,13 +258,15 @@
                 </thead>
                 <tbody>
                     {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-                        {% set field = layoutField.getField() %}
-                        {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
-                        {% set template = fieldClass.getMappingTemplate() %}
+                        {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+                        {% if field %}
+                            {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
+                            {% set template = fieldClass.getMappingTemplate() %}
 
-                        {% set variables = { name: field.name, handle: field.handle, feed: feed, feedData: feedData, field: field, fieldClass: fieldClass } %}
+                            {% set variables = { name: field.name, handle: field.handle, feed: feed, feedData: feedData, field: field, fieldClass: fieldClass } %}
 
-                        {% include template ignore missing with variables only %}
+                            {% include template ignore missing with variables only %}
+                        {% endif %}
                     {% endfor %}
                 </tbody>
             </table>
@@ -293,14 +295,16 @@
                 </thead>
                 <tbody>
                     {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-                        {% set field = layoutField.getField() %}
-                        {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
-                        {% set template = fieldClass.getMappingTemplate() %}
-                        {% set handle = 'variant-' ~ field.handle %}
+                        {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+                        {% if field %}
+                            {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
+                            {% set template = fieldClass.getMappingTemplate() %}
+                            {% set handle = 'variant-' ~ field.handle %}
 
-                        {% set variables = { name: field.name, handle: handle, feed: feed, feedData: feedData, field: field, fieldClass: fieldClass } %}
+                            {% set variables = { name: field.name, handle: handle, feed: feed, feedData: feedData, field: field, fieldClass: fieldClass } %}
 
-                        {% include template ignore missing with variables only %}
+                            {% include template ignore missing with variables only %}
+                        {% endif %}
                     {% endfor %}
                 </tbody>
             </table>
@@ -324,15 +328,19 @@
 
 {% for tab in productTabs %}
     {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-        {% set field = layoutField.getField() %}
-        {% set uniqueFields = uniqueFields|merge([{ name: field.name, handle: field.handle, type: className(field) }]) %}
+        {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+        {% if field %}
+            {% set uniqueFields = uniqueFields|merge([{ name: field.name, handle: field.handle, type: className(field) }]) %}
+        {% endif %}
     {% endfor %}
 {% endfor %}
 
 {% for tab in variantTabs %}
     {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-        {% set field = layoutField.getField() %}
-        {% set uniqueFields = uniqueFields|merge([{ name: field.name, handle: 'variant-' ~ field.handle, type: className(field) }]) %}
+        {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+        {% if field %}
+            {% set uniqueFields = uniqueFields|merge([{ name: field.name, handle: 'variant-' ~ field.handle, type: className(field) }]) %}
+        {% endif %}
     {% endfor %}
 {% endfor %}
 

--- a/src/templates/_includes/elements/digital-products/map.html
+++ b/src/templates/_includes/elements/digital-products/map.html
@@ -127,13 +127,15 @@
             </thead>
             <tbody>
                 {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-                    {% set field = layoutField.getField() %}
-                    {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
-                    {% set template = fieldClass.getMappingTemplate() %}
+                    {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+                    {% if field %}
+                        {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
+                        {% set template = fieldClass.getMappingTemplate() %}
 
-                    {% set variables = { name: field.name, handle: field.handle, feed: feed, feedData: feedData, field: field, fieldClass: fieldClass } %}
+                        {% set variables = { name: field.name, handle: field.handle, feed: feed, feedData: feedData, field: field, fieldClass: fieldClass } %}
 
-                    {% include template ignore missing with variables only %}
+                        {% include template ignore missing with variables only %}
+                    {% endif %}
                 {% endfor %}
             </tbody>
         </table>
@@ -147,8 +149,10 @@
 
 {% for tab in tabs %}
     {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-        {% set field = layoutField.getField() %}
-        {% set fields = fields|merge([{ name: field.name, handle: field.handle, type: className(field) }]) %}
+        {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+        {% if field %}
+            {% set fields = fields|merge([{ name: field.name, handle: field.handle, type: className(field) }]) %}
+        {% endif %}
     {% endfor %}
 {% endfor %}
 

--- a/src/templates/_includes/elements/entries/map.html
+++ b/src/templates/_includes/elements/entries/map.html
@@ -152,13 +152,15 @@
             </thead>
             <tbody>
                 {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-                    {% set field = layoutField.getField() %}
-                    {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
-                    {% set template = fieldClass.getMappingTemplate() %}
+                    {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+                    {% if field %}
+                        {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
+                        {% set template = fieldClass.getMappingTemplate() %}
 
-                    {% set variables = { name: field.name, handle: field.handle, feed: feed, feedData: feedData, field: field, fieldClass: fieldClass } %}
+                        {% set variables = { name: field.name, handle: field.handle, feed: feed, feedData: feedData, field: field, fieldClass: fieldClass } %}
 
-                    {% include template ignore missing with variables only %}
+                        {% include template ignore missing with variables only %}
+                    {% endif %}
                 {% endfor %}
             </tbody>
         </table>
@@ -173,8 +175,10 @@
 
     {% for tab in tabs %}
         {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-            {% set field = layoutField.getField() %}
-            {% set fields = fields|merge([{ name: field.name, handle: field.handle, type: className(field) }]) %}
+            {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+            {% if field %}
+                {% set fields = fields|merge([{ name: field.name, handle: field.handle, type: className(field) }]) %}
+            {% endif %}
         {% endfor %}
     {% endfor %}
 

--- a/src/templates/_includes/elements/global-sets/map.html
+++ b/src/templates/_includes/elements/global-sets/map.html
@@ -24,13 +24,15 @@
             </thead>
             <tbody>
                 {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-                    {% set field = layoutField.getField() %}
-                    {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
-                    {% set template = fieldClass.getMappingTemplate() %}
+                    {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+                    {% if field %}
+                        {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
+                        {% set template = fieldClass.getMappingTemplate() %}
 
-                    {% set variables = { name: field.name, handle: field.handle, feed: feed, feedData: feedData, field: field, fieldClass: fieldClass } %}
+                        {% set variables = { name: field.name, handle: field.handle, feed: feed, feedData: feedData, field: field, fieldClass: fieldClass } %}
 
-                    {% include template ignore missing with variables only %}
+                        {% include template ignore missing with variables only %}
+                    {% endif %}
                 {% endfor %}
             </tbody>
         </table>

--- a/src/templates/_includes/elements/tag/map.html
+++ b/src/templates/_includes/elements/tag/map.html
@@ -75,13 +75,15 @@
             </thead>
             <tbody>
                 {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-                    {% set field = layoutField.getField() %}
-                    {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
-                    {% set template = fieldClass.getMappingTemplate() %}
+                    {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+                    {% if field %}
+                        {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
+                        {% set template = fieldClass.getMappingTemplate() %}
 
-                    {% set variables = { name: field.name, handle: field.handle, feed: feed, feedData: feedData, field: field, fieldClass: fieldClass } %}
+                        {% set variables = { name: field.name, handle: field.handle, feed: feed, feedData: feedData, field: field, fieldClass: fieldClass } %}
 
-                    {% include template ignore missing with variables only %}
+                        {% include template ignore missing with variables only %}
+                    {% endif %}
                 {% endfor %}
             </tbody>
         </table>
@@ -95,8 +97,10 @@
 
 {% for tab in tabs %}
     {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-        {% set field = layoutField.getField() %}
-        {% set fields = fields|merge([{ name: field.name, handle: field.handle, type: className(field) }]) %}
+        {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+        {% if field %}
+            {% set fields = fields|merge([{ name: field.name, handle: field.handle, type: className(field) }]) %}
+        {% endif %}
     {% endfor %}
 {% endfor %}
 

--- a/src/templates/_includes/elements/user/map.html
+++ b/src/templates/_includes/elements/user/map.html
@@ -167,21 +167,23 @@
         </thead>
         <tbody>
             {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-                {% set field = layoutField.getField() %}
-                {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
+                {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+                {% if field %}
+                    {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
 
-                {% set variables = {
-                    name: field.name,
-                    handle: field.handle,
-                    feed: feed,
-                    feedData: feedData,
-                    field: field,
-                    fieldClass: fieldClass
-                } %}
+                    {% set variables = {
+                        name: field.name,
+                        handle: field.handle,
+                        feed: feed,
+                        feedData: feedData,
+                        field: field,
+                        fieldClass: fieldClass
+                    } %}
 
-                {% set template = fieldClass.getMappingTemplate() %}
+                    {% set template = fieldClass.getMappingTemplate() %}
 
-                {% include template ignore missing with variables only %}
+                    {% include template ignore missing with variables only %}
+                {% endif %}
             {% endfor %}
         </tbody>
     </table>
@@ -194,8 +196,10 @@
 
 {% for tab in tabs %}
     {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-        {% set field = layoutField.getField() %}
-        {% set fields = fields|merge([{ name: field.name, handle: field.handle, type: className(field) }]) %}
+        {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+        {% if field %}
+            {% set fields = fields|merge([{ name: field.name, handle: field.handle, type: className(field) }]) %}
+        {% endif %}
     {% endfor %}
 {% endfor %}
 

--- a/src/templates/_includes/fields/addresses.html
+++ b/src/templates/_includes/fields/addresses.html
@@ -53,20 +53,23 @@
 {% if fieldLayout %}
     {% for tab in fieldLayout.getTabs() %}
         {% for layoutField in tab.getElements()|filter(e => e is instance of ('craft\\fieldlayoutelements\\BaseField')) %}
+            {% set fieldClass = null %}
             {% if layoutField is instance of ('craft\\fieldlayoutelements\\CustomField') %}
-                {% set field = layoutField.getField() %}
-                {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
-                {% set path = prefixPath|merge(['fields', field.handle]) %}
+                {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+                {% if field %}
+                    {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
+                    {% set path = prefixPath|merge(['fields', field.handle]) %}
 
-                {% set variables = {
-                    name: field.name,
-                    handle: field.handle,
-                    feed: feed,
-                    feedData: feedData,
-                    field: field,
-                    fieldClass: fieldClass,
-                    path: path
-                } %}
+                    {% set variables = {
+                        name: field.name,
+                        handle: field.handle,
+                        feed: feed,
+                        feedData: feedData,
+                        field: field,
+                        fieldClass: fieldClass,
+                        path: path
+                    } %}
+                {% endif %}
             {% else %}
                 {% set fieldClass = craft.feedme.fields.getRegisteredNativeField(className(layoutField)) %}
                 {% set path = prefixPath|merge(['nativeFields', layoutField.attribute]) %}
@@ -82,9 +85,11 @@
                 } %}
             {% endif %}
 
-            {% set template = fieldClass.getMappingTemplate() %}
+            {% if fieldClass %}
+                {% set template = fieldClass.getMappingTemplate() %}
 
-            {% include template ignore missing with variables only %}
+                {% include template ignore missing with variables only %}
+            {% endif %}
         {% endfor %}
     {% endfor %}
 {% endif %}

--- a/src/templates/_includes/fields/matrix.html
+++ b/src/templates/_includes/fields/matrix.html
@@ -108,37 +108,39 @@
                     </tr>
 
                     {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
-                        {% set field = layoutField.getField() %}
-                        {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
-                        {% set template = fieldClass.getMappingTemplate() %}
+                        {% set field = craft.feedme.fields.getFieldFromLayoutElement(layoutField) %}
+                        {% if field %}
+                            {% set fieldClass = craft.feedme.fields.getRegisteredField(className(field)) %}
+                            {% set template = fieldClass.getMappingTemplate() %}
 
-                        {% set nameLabel = entryType.name ~ ': ' ~ field.name %}
-                        {% set instructionsHandle = handle ~ '[' ~ entryType.handle ~ '][' ~ field.handle ~ ']' %}
+                            {% set nameLabel = entryType.name ~ ': ' ~ field.name %}
+                            {% set instructionsHandle = handle ~ '[' ~ entryType.handle ~ '][' ~ field.handle ~ ']' %}
 
-                        {% set parentPath = [ handle, 'blocks', entryType.handle, 'fields', field.handle ] %}
+                            {% set parentPath = [ handle, 'blocks', entryType.handle, 'fields', field.handle ] %}
 
-                        {% set variables = {
-                            name: field.name,
-                            handle: field.handle,
-                            feed: feed,
-                            feedData: feedData,
-                            field: field,
-                            fieldClass: fieldClass,
-                            path: parentPath,
-                            parentPath: parentPath,
-                            classes: ['inner-matrix']
-                        }
-                        %}
+                            {% set variables = {
+                                name: field.name,
+                                handle: field.handle,
+                                feed: feed,
+                                feedData: feedData,
+                                field: field,
+                                fieldClass: fieldClass,
+                                path: parentPath,
+                                parentPath: parentPath,
+                                classes: ['inner-matrix']
+                            }
+                            %}
 
-                        {% if fieldClass is instance of ('craft\\feedme\\fields\\Matrix') %}
-                            {% include template ignore missing with {
-                                nestedField: true,
-                                nameLabel: field.name,
-                                instructionsHandle: field.handle,
-                                instructions: 'Importing to a matrix in a matrix isn\'t yet supported.'
-                            } only %}
-                        {% else %}
-                            {% include template ignore missing with variables only %}
+                            {% if fieldClass is instance of ('craft\\feedme\\fields\\Matrix') %}
+                                {% include template ignore missing with {
+                                    nestedField: true,
+                                    nameLabel: field.name,
+                                    instructionsHandle: field.handle,
+                                    instructions: 'Importing to a matrix in a matrix isn\'t yet supported.'
+                                } only %}
+                            {% else %}
+                                {% include template ignore missing with variables only %}
+                            {% endif %}
                         {% endif %}
                     {% endfor %}
                 {% endfor %}


### PR DESCRIPTION
### Description
Issue: Changes in cms `5.8.13` and `5.8.13.1` are causing the Feed Me mapping screen to throw `FieldNotFoundException` if the field layout contains a field that has been deleted (but not removed from the layout).

Solution: 
I created a method that catches the `FieldNotFoundException` exception that is thrown if the field cannot be found, and implemented additional safeguards so that fields that cannot be found are ignored during the mapping process.

### Related issues
#1679 
