### PR TITLE
don't duplicate the filename extension

### DIFF
--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -16,6 +16,7 @@ use craft\feedme\Plugin;
 use craft\fields\Assets as AssetsField;
 use craft\helpers\Db;
 use craft\helpers\Json;
+use craft\helpers\StringHelper;
 use craft\helpers\UrlHelper;
 
 /**
@@ -187,7 +188,11 @@ class Assets extends Field implements FieldInterface
                         // if we can determine the extension of the remote file, use that extension
                         $remoteUrlExtension = AssetHelper::getRemoteUrlExtension($urlsToUpload[$key]['value']);
                         if (!empty($remoteUrlExtension)) {
-                            $filename .= '.' . $remoteUrlExtension;
+                            $localExtension = StringHelper::toLowerCase(pathinfo($filename, PATHINFO_EXTENSION));
+                            if ($localExtension !== $remoteUrlExtension) {
+                                $filename = pathinfo($filename, PATHINFO_FILENAME);
+                                $filename .= '.' . $remoteUrlExtension;
+                            }
                         }
 
                         $urlsToUpload[$key]['newFilename'] = $filename;


### PR DESCRIPTION
### Description
When importing an asset via the Inner-Element Field (Assets field) and providing a filename for it, ensure that we don’t end up with a filename with two extensions. 

For example, if the filename provided in the feed is: `my-file.jpg` and the imported asset is called `remote-image.jpg`, the imported file should be named `my-file.jpg` and not `my-file.jpg.jpg`. 

If the remote file extension is detected to be a `png` but the filename provided in the feed is `jpg`, the `png` extension will be used.


### Related issues
#1677 
