### PR TITLE
respect setEmptyValues for matrix blocks

### DIFF
--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -163,9 +163,11 @@ class Matrix extends Field implements FieldInterface
             $preppedData[$blockIndex . '.fields.' . $subFieldHandle] = $value;
         }
 
-        // if there's nothing in the prepped data, return null, as if mapping doesn't exist
+        // if there's nothing in the prepped data,
+        // if setEmptyValues is on, return an empty array so that existing blocks are removed,
+        // otherwise return null, as if mapping doesn't exist
         if (empty($preppedData)) {
-            return null;
+            return $this->feed['setEmptyValues'] ? [] : null;
         }
 
         $expanded = Hash::expand($preppedData);


### PR DESCRIPTION
### Description
Respect the `setEmptyValues` settings for matrix blocks too. 

Example: 
- you have two existing entries, each with a matrix field with one block
- you map the fields inside the matrix block to your feed data
- the feed data for one of those entries changes, and the value of the matrix field is now empty
- if you have `setEmptyValues` turned on, the block for that entry should be removed
- if you have `setEmptyValues` turned off, the block for that entry should stay intact


### Related issues
#1684 
