### PR TITLE
when feeds are queued via cli, process them sequentially

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes for Feed Me
 
+## Unreleased
+- Multiple feeds queued via single CLI command are now processed sequentially, even if they’re batched. ([#1695](https://github.com/craftcms/feed-me/issues/1695)) 
+
 ## 5.13.1 - 2025-10-23
 
 - Fixed a bug where some imported assets would end up with a double file extension. ([#1688](https://github.com/craftcms/feed-me/pull/1688))

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -16,10 +16,12 @@ use craft\feedme\services\Process;
 use craft\feedme\services\Service;
 use craft\feedme\web\twig\Extension;
 use craft\feedme\web\twig\variables\FeedMeVariable;
+use craft\helpers\Db;
 use craft\helpers\UrlHelper;
 use craft\services\Gc;
 use craft\web\twig\variables\CraftVariable;
 use craft\web\UrlManager;
+use DateTime;
 use yii\base\Event;
 use yii\di\Instance;
 use yii\queue\Queue;
@@ -63,7 +65,7 @@ class Plugin extends \craft\base\Plugin
     }
 
     public string $minVersionRequired = '4.4.8';
-    public string $schemaVersion = '5.1.1';
+    public string $schemaVersion = '5.14.0';
     public bool $hasCpSettings = true;
     public bool $hasCpSection = true;
 
@@ -180,7 +182,20 @@ class Plugin extends \craft\base\Plugin
             Gc::EVENT_RUN,
             function(Event $event) {
                 $this->getLogs()->prune();
+                $this->_deleteStaleSequences();
             }
         );
+    }
+
+    /**
+     * Delete stale feed processing sequences.
+     *
+     * @return void
+     * @throws \yii\db\Exception
+     */
+    private function _deleteStaleSequences(): void
+    {
+        $condition = ['<', 'timestamp', Db::prepareDateForDb(new DateTime('2 weeks ago'))];
+        Db::delete('{{%feedme_sequences}}', $condition);
     }
 }

--- a/src/console/controllers/FeedsController.php
+++ b/src/console/controllers/FeedsController.php
@@ -2,10 +2,16 @@
 
 namespace craft\feedme\console\controllers;
 
+use craft\feedme\models\FeedModel;
 use craft\feedme\Plugin;
 use craft\feedme\queue\jobs\FeedImport;
+use craft\feedme\records\SequencesRecord;
 use craft\helpers\Console;
+use craft\helpers\DateTimeHelper;
+use craft\helpers\Db;
+use craft\helpers\Json;
 use craft\helpers\Queue;
+use craft\helpers\StringHelper;
 use yii\console\Controller;
 use yii\console\ExitCode;
 
@@ -65,9 +71,17 @@ class FeedsController extends Controller
         $feeds = Plugin::getInstance()->getFeeds();
         $tally = 0;
 
+        $key = StringHelper::randomString(10);
+        $options = Json::encode([
+            'limit' => $this->limit,
+            'offset' => $this->offset,
+            'continueOnError' => $this->continueOnError,
+        ]);
+        $timestamp = Db::prepareDateForDb(DateTimeHelper::now());
+
         if ($this->all) {
             foreach ($feeds->getFeeds() as $feed) {
-                $this->queueFeed($feed, null, null, $this->continueOnError);
+                $this->addFeedToSequence($feed,$key, $options, $timestamp);
                 $tally++;
             }
         } elseif ($feedId) {
@@ -81,7 +95,7 @@ class FeedsController extends Controller
                     continue;
                 }
 
-                $this->queueFeed($feed, $this->limit, $this->offset, $this->continueOnError);
+                $this->addFeedToSequence($feed, $key, $options, $timestamp);
                 $tally++;
             }
         }
@@ -91,6 +105,8 @@ class FeedsController extends Controller
         } else {
             $this->stdout('Could not determine the feeds to process.' . PHP_EOL, Console::FG_GREEN);
         }
+
+        $this->queueFirstFeed($key);
 
         return ExitCode::OK;
     }
@@ -105,17 +121,59 @@ class FeedsController extends Controller
      */
     protected function queueFeed($feed, $limit = null, $offset = null, bool $continueOnError = false): void
     {
-        $this->stdout('Queuing up feed ');
-        $this->stdout($feed->name, Console::FG_CYAN);
-        $this->stdout(' ... ');
-
         Queue::push(new FeedImport([
             'feed' => $feed,
             'limit' => $limit,
             'offset' => $offset,
             'continueOnError' => $continueOnError,
         ]));
+    }
+
+    /**
+     * Add feeds to a sequence, so that they're processed in order in which they were provided.
+     *
+     * @param FeedModel $feed
+     * @param string $key
+     * @param string $options
+     * @param string $timestamp
+     * @return void
+     * @throws \yii\db\Exception
+     */
+    protected function addFeedToSequence(FeedModel $feed, string $key, string $options, string $timestamp): void
+    {
+        $this->stdout('Queuing up feed ');
+        $this->stdout($feed->name, Console::FG_CYAN);
+        $this->stdout(' ... ');
+
+        Db::insert('{{%feedme_sequences}}', [
+            'feedId' => $feed->id,
+            'key' => $key,
+            'options' => $options,
+            'timestamp' => $timestamp,
+        ]);
 
         $this->stdout('done' . PHP_EOL, Console::FG_GREEN);
+    }
+
+    /**
+     * Queue first feed from a sequence.
+     *
+     * @param string $key
+     * @return void
+     * @throws \yii\base\InvalidConfigException
+     */
+    protected function queueFirstFeed(string $key): void
+    {
+        $firstFeed = SequencesRecord::find()->select(['feedId', 'options'])->where(['key' => $key])->one();
+        $id = $firstFeed['feedId'];
+        $options = Json::decode($firstFeed['options']);
+
+        $feed = Plugin::getInstance()->getFeeds()->getFeedById($id);
+
+        if (!$feed) {
+            $this->stderr("Invalid feed ID: $id" . PHP_EOL, Console::FG_RED);
+        }
+
+        $this->queueFeed($feed, $options['limit'], $options['offset'], $options['continueOnError']);
     }
 }

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -67,6 +67,19 @@ class Install extends Migration
 
         $this->createIndex('idx_log_level', '{{%feedme_logs}}', 'level');
         $this->createIndex('idx_log_category', '{{%feedme_logs}}', 'category');
+
+
+        $this->archiveTableIfExists('{{%feedme_sequences}}');
+        $this->createTable('{{%feedme_sequences}}', [
+            'id' => $this->primaryKey(),
+            'key' => $this->string()->notNull(),
+            'feedId' => $this->integer()->notNull(),
+            'options' => $this->text(),
+            'timestamp' => $this->dateTime()->notNull(),
+        ]);
+
+        $this->createIndex('idx_sequence_key', '{{%feedme_sequences}}', 'key');
+        $this->createIndex('idx_sequence_feedId', '{{%feedme_sequences}}', 'feedId');
     }
 
     protected function removeTables(): void

--- a/src/migrations/m251024_130344_add_sequences_table.php
+++ b/src/migrations/m251024_130344_add_sequences_table.php
@@ -2,7 +2,6 @@
 
 namespace craft\feedme\migrations;
 
-use Craft;
 use craft\db\Migration;
 
 /**

--- a/src/migrations/m251024_130344_add_sequences_table.php
+++ b/src/migrations/m251024_130344_add_sequences_table.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace craft\feedme\migrations;
+
+use Craft;
+use craft\db\Migration;
+
+/**
+ * m251024_130344_add_sequences_table migration.
+ */
+class m251024_130344_add_sequences_table extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->createTable('{{%feedme_sequences}}', [
+            'id' => $this->primaryKey(),
+            'key' => $this->string()->notNull(),
+            'feedId' => $this->integer()->notNull(),
+            'options' => $this->text(),
+            'timestamp' => $this->dateTime()->notNull(),
+        ]);
+
+        $this->createIndex('idx_sequence_key', '{{%feedme_sequences}}', 'key');
+        $this->createIndex('idx_sequence_feedId', '{{%feedme_sequences}}', 'feedId');
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        $this->dropTableIfExists('{{%feedme_sequences}}');
+
+        return true;
+    }
+}

--- a/src/queue/jobs/FeedImport.php
+++ b/src/queue/jobs/FeedImport.php
@@ -9,7 +9,10 @@ use craft\feedme\datatypes\DataBatcher;
 use craft\feedme\events\FeedProcessEvent;
 use craft\feedme\models\FeedModel;
 use craft\feedme\Plugin;
+use craft\feedme\records\SequencesRecord;
 use craft\feedme\services\Process;
+use craft\helpers\Db;
+use craft\helpers\Json;
 use craft\helpers\Queue;
 use craft\queue\BaseBatchedJob;
 use Throwable;
@@ -197,6 +200,8 @@ class FeedImport extends BaseBatchedJob implements RetryableJobInterface
             } else {
                 // Only perform the afterProcessFeed function after any/all pagination is done
                 $processService->afterProcessFeed($this->_feedSettings, $this->feed, $this->processedElementIds, $this->startTime);
+
+                $this->maybeProcessSequencedFeeds($this->feed->id);
             }
         }
     }
@@ -210,5 +215,52 @@ class FeedImport extends BaseBatchedJob implements RetryableJobInterface
     protected function defaultDescription(): string
     {
         return Craft::t('feed-me', 'Running {name} feed.', ['name' => $this->feed->name]);
+    }
+
+    /**
+     * Check if the feed that was just processed was part of a sequence.
+     * If so, check if there are any other feeds left in the same sequence, and if there are, process the next one.
+     *
+     * @param $id
+     * @return void
+     * @throws \yii\base\InvalidConfigException
+     * @throws \yii\db\Exception
+     */
+    protected function maybeProcessSequencedFeeds($id): void
+    {
+        // find the key of the feed in feedme_sequences table
+        $sequenceKey = SequencesRecord::find()
+            ->select('key')
+            ->where(['feedId' => $id])
+            ->scalar();
+
+        // if there is one, delete the row with the current feed ID from it and then get the next feed key and queue it up
+        if ($sequenceKey) {
+            Db::delete('{{%feedme_sequences}}', ['feedId' => $id, 'key' => $sequenceKey]);
+
+            $nextFeed = SequencesRecord::find()
+                ->select(['feedId', 'options'])
+                ->where(['key' => $sequenceKey])
+                ->one();
+
+            if ($nextFeed) {
+                $feed = Plugin::getInstance()->getFeeds()->getFeedById($nextFeed['feedId']);
+                $nextFeedId = $nextFeed['feedId'];
+                $options = Json::decode($nextFeed['options']);
+
+                if (!$feed) {
+                    // if we didn't find a feed with this ID, check if we have a next one
+                    Plugin::error("Invalid feed ID: $nextFeedId");
+                    $this->maybeProcessSequencedFeeds($nextFeedId);
+                } else {
+                    Queue::push(new FeedImport([
+                        'feed' => $feed,
+                        'limit' => $options['limit'],
+                        'offset' => $options['offset'],
+                        'continueOnError' => $options['continueOnError'],
+                    ]));
+                }
+            }
+        }
     }
 }

--- a/src/records/SequencesRecord.php
+++ b/src/records/SequencesRecord.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace craft\feedme\records;
+
+use craft\db\ActiveRecord;
+
+class SequencesRecord extends ActiveRecord
+{
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * @inheritDoc
+     */
+    public static function tableName(): string
+    {
+        return '{{%feedme_sequences}}';
+    }
+}


### PR DESCRIPTION
### Description
When feeds are queued via CLI, process them sequentially, so that all batches from the first feed are processed before the second feed is started, and so on.

Testing steps:
- create a (local) filesystem and then a volume that uses it
- create Assets type field
- create a section with an entry type that uses the assets field
- create first feed (`feed1`) that imports assets into the volume (example data below)
- create a second feed (`feed2`) that imports entries into the section; the entries rely on assets already having been imported (example data below)
- for ease of testing, so that you don’t have to have feeds with over 100 items, you can set `public int $batchSize = 1;` in `src/queue/jobs/FeedImport.php`
- run `craft feed-me/feeds/queue 1,2` command (where `1` and `2` correspond actual IDs of the `feed1` and `feed2` respectively)

The outcome should be that all the assets are processed first before we move onto the entries.

`feed1` example data:
```
{
  "assets":[
    {
      "url": "<URL>",
      "filename": "img1.jpg"
    },
    {
      "url": "<URL>",
      "filename": "img2.jpg"
    }
  ]
}
```

`feed2` example data:
```
{
  "entries": [
    {
      "title": "entry 1",
      "image": "img2.jpg"
    },
    {
      "title": "entry 2",
      "image": "img1.jpg"
    }
  ]
}
```

### Related issues
#1695
