### PR TITLE
account for the fact that node might be nested

### DIFF
--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -243,9 +243,9 @@ abstract class Field extends Component
         $nodeKey = null;
 
         if (!empty($nodeName)) {
-            preg_match('/\/(\d+)\//', $nodeName, $matches);
-            if (isset($matches[1])) {
-                $nodeKey = $matches[1];
+            preg_match_all('/\/(\d+)\//', $nodeName, $matches);
+            if (!empty($matches[1])) {
+                $nodeKey = end($matches[1]);
             }
         }
 

--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -244,7 +244,7 @@ abstract class Field extends Component
 
         if (!empty($nodeName)) {
             preg_match_all('/\/(\d+)\//', $nodeName, $matches);
-            if (!empty($matches[1])) {
+            if (!empty($matches[1]) && is_array($matches[1])) {
                 $nodeKey = end($matches[1]);
             }
         }


### PR DESCRIPTION
### Description
Follow up to https://github.com/craftcms/feed-me/pull/1278 and https://github.com/craftcms/feed-me/pull/1383.

**Issue:** When you import into a matrix field with a relation field in it and want to map inner element fields for that relation field, only the content from the first element is used to populate inner fields for all elements.

**Solution:** account for the fact that the element’s inner fields mapping path might be nested. 

For example, when the node name was `matrix/0/images/1/url`, the node key was mistakenly identified as `0`, causing only the first value to be imported for all the matrix nested element inner fields.

### Related issues
#1691
