### PR TITLE
pass only existing elements to the elementSelectField

### DIFF
--- a/src/templates/_includes/fields/_base.html
+++ b/src/templates/_includes/fields/_base.html
@@ -176,7 +176,10 @@
                             {% set elements = [] %}
 
                             {% for elementId in defaultValue %}
-                                {% set elements = elements|merge([ craft.app.elements.getElementById(elementId) ]) %}
+                                {% set element = craft.app.elements.getElementById(elementId) %}
+                                {% if element is not empty %}
+                                    {% set elements = elements|merge([element]) %}
+                                {% endif %}
                             {% endfor %}
 
                             {{ forms.elementSelectField({


### PR DESCRIPTION
### Description
When displaying the default relation field value on the feed’s mapping screen, only pass the existing elements to the `elementSelectField()`.

The error is only thrown in Feed Me v6 (for Craft v5), but fixing in v5 (for Craft v4) for consistency.


### Related issues
#1692 
