### PR TITLE
Added support for custom field matching on Commerce Products and Variants fields

### DIFF
--- a/src/fields/CommerceProducts.php
+++ b/src/fields/CommerceProducts.php
@@ -65,7 +65,7 @@ class CommerceProducts extends Field implements FieldInterface
         }
 
         $match = Hash::get($this->fieldInfo, 'options.match', 'title');
-        $specialMatchCase = in_array($match, ['title', 'slug']);
+        $specialMatchCase = in_array($match, ['title', 'slug', 'defaultSku']);
 
         // if value from the feed is empty and default is not set
         // return an empty array; no point bothering further

--- a/src/fields/CommerceVariants.php
+++ b/src/fields/CommerceVariants.php
@@ -65,7 +65,7 @@ class CommerceVariants extends Field implements FieldInterface
         }
 
         $match = Hash::get($this->fieldInfo, 'options.match', 'title');
-        $specialMatchCase = $match === 'title';
+        $specialMatchCase = in_array($match, ['title', 'sku']);
 
         // if value from the feed is empty and default is not set
         // return an empty array; no point bothering further

--- a/src/templates/_includes/fields/commerce_products.html
+++ b/src/templates/_includes/fields/commerce_products.html
@@ -28,15 +28,26 @@
     <div class="element-match">
         <span>{{ 'Data provided for this product is:'|t('feed-me') }}</span>
 
+        {% set matchAttributes = [
+            { value: 'title', label: 'Title'|t('feed-me') },
+            { value: 'elements.id', label: 'ID'|t('feed-me') },
+            { value: 'slug', label: 'Slug'|t('feed-me') },
+            { value: 'defaultSku', label: 'Default SKU'|t('feed-me') },
+        ] %}
+
+        {% for field in craft.app.fields.getAllFields() %}
+            {% if craft.feedme.fieldCanBeUniqueId(field) %}
+                {# Check for columnSuffix (since 3.7) #}
+                {% set suffix = field['columnSuffix'] is defined and field.columnSuffix|length ? '_' ~ field.columnSuffix : '' %}
+                {% set matchAttributes = matchAttributes|merge({ ('field_' ~ field.handle ~ suffix): field.name }) %}
+            {% endif %}
+        {% endfor %}
+
         {{ forms.selectField({
             name: 'options[match]',
             class: '',
             value: hash_get(feed.fieldMapping, optionsPath ~ '.match') ?: '',
-            options: [
-                { value: 'title', label: 'Title'|t('feed-me') },
-                { value: 'elements.id', label: 'ID'|t('feed-me') },
-                { value: 'slug', label: 'Slug'|t('feed-me') },
-            ],
+            options: matchAttributes,
         }) }}
     </div>
 {% endblock %}

--- a/src/templates/_includes/fields/commerce_variants.html
+++ b/src/templates/_includes/fields/commerce_variants.html
@@ -28,15 +28,25 @@
     <div class="element-match">
         <span>{{ 'Data provided for this variant is:'|t('feed-me') }}</span>
 
+        {% set matchAttributes = [
+            { value: 'title', label: 'Title'|t('feed-me') },
+            { value: 'elements.id', label: 'ID'|t('feed-me') },
+            { value: 'sku', label: 'SKU'|t('feed-me') },
+        ] %}
+
+        {% for field in craft.app.fields.getAllFields() %}
+            {% if craft.feedme.fieldCanBeUniqueId(field) %}
+                {# Check for columnSuffix (since 3.7) #}
+                {% set suffix = field['columnSuffix'] is defined and field.columnSuffix|length ? '_' ~ field.columnSuffix : '' %}
+                {% set matchAttributes = matchAttributes|merge({ ('field_' ~ field.handle ~ suffix): field.name }) %}
+            {% endif %}
+        {% endfor %}
+
         {{ forms.selectField({
             name: 'options[match]',
             class: '',
             value: hash_get(feed.fieldMapping, optionsPath ~ '.match') ?: '',
-            options: [
-                { value: 'title', label: 'Title'|t('feed-me') },
-                { value: 'elements.id', label: 'ID'|t('feed-me') },
-                { value: 'sku', label: 'SKU'|t('feed-me') },
-            ],
+            options: matchAttributes,
         }) }}
     </div>
 {% endblock %}


### PR DESCRIPTION
### Description

I created this pull request to address #902. To add a bit more context regarding our specific use case, we use a PIM to manage our product data, and import the product data into Craft using Feed Me. Currently, there is no way to match Commerce Products or Variants fields using custom fields as is possible for with other element fields like Entries. It's also not possible to match Commerce Products by default SKU.

As a result, the only way we're currently able to match Commerce elements is by ID, which requires ingesting that data from Craft back into our PIM. This PR would allow us to match products and variants using data that is already in our PIM instead, reducing additional work.

While I'm not deeply familiar with the inner workings of Feed Me, it seemed like the functionality to support this was already in place and it mostly needed field options to be populated for selection. I tested matching products using default SKU and a custom field in my local dev environment, and both worked without issue.

Thanks for your consideration!