### PR TITLE
v6 with adapter - compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Feed Me is a Craft plugin for super-simple importing of content, either once-off
 
 ## Requirements
 
-This plugin requires Craft CMS 5.0.0-beta.2 or later.
+This plugin requires Craft CMS 5.0.0-beta.2+ or 6.0.0-alpha.1+ with the `craftcms/yii2-adapter` package.
 
 ## Installation
 
@@ -45,6 +45,7 @@ return [
     'logging' => false,
 ];
 ```
+use `config/craft/feed-me.php` if you’re using Craft CMS v6
 
 ### config/app.php
 
@@ -77,6 +78,7 @@ return [
     ],
 ];
 ```
+use `config/craft/app.php` if you’re using Craft CMS v6
 
 ## Resources
 

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,13 @@
     "issues": "https://github.com/craftcms/feed-me/issues?state=open",
     "source": "https://github.com/craftcms/feed-me",
     "docs": "https://docs.craftcms.com/feed-me/v6/",
-    "rss": "https://github.com/craftcms/feed-me/commits/master.atom"
+    "rss": "https://github.com/craftcms/feed-me/commits/6.x.atom"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
     "php": "^8.2",
-    "craftcms/cms": "^5.6.0",
+    "craftcms/cms": "^5.6.0|^6.0.0-alpha.1",
     "cakephp/utility": "^5.0.0",
     "jakeasmith/http_build_url": "^1.0",
     "nesbot/carbon": "^2.10|^3.0.0",
@@ -56,7 +56,7 @@
   "extra": {
     "name": "Feed Me",
     "handle": "feed-me",
-    "documentationUrl": "https://docs.craftcms.com/feed-me/v4/"
+    "documentationUrl": "https://docs.craftcms.com/feed-me/v6/"
   },
   "scripts": {
     "check-cs": "ecs check --ansi",


### PR DESCRIPTION
### Description
Makes the plugin compatible with cms v6 when using the `yii2-adapter` package.

WIP; more changes might be needed


### Related issues

