### PR TITLE
Feature/902 custom field mapping for products and variants fields

### DIFF
--- a/src/fields/CommerceProducts.php
+++ b/src/fields/CommerceProducts.php
@@ -6,12 +6,18 @@ use Cake\Utility\Hash;
 use Craft;
 use craft\commerce\elements\Product as ProductElement;
 use craft\commerce\fields\Products;
+use craft\commerce\fields\Variants;
+use craft\commerce\Plugin as CommercePlugin;
 use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
 use craft\feedme\helpers\DataHelper;
+use craft\feedme\helpers\FieldHelper;
+use craft\feedme\models\FeedModel;
 use craft\feedme\Plugin;
+use craft\fields\BaseRelationField;
 use craft\helpers\Db;
 use craft\helpers\Json;
+use Illuminate\Support\Collection;
 
 /**
  *
@@ -156,5 +162,80 @@ class CommerceProducts extends Field implements FieldInterface
         }
 
         return $foundElements;
+    }
+
+    /**
+     * Returns an array of custom fields that can be used when querying for matching products.
+     *
+     * If a field is passed, use the field layouts linked to the sources allowed by the Commerce Products field.
+     * If all the sources are native (product types), then only fields from all those product types' field layouts will be returned.
+     * If there's at least one custom source in the mix, the above list will be followed by a list of all the fields.
+     * If only custom sources are selected, return all the fields in the installation.
+     *
+     * @param FeedModel $feed
+     * @param BaseRelationField|null $field
+     * @return array
+     */
+    public static function getMatchFields(FeedModel $feed, ?BaseRelationField $field = null): array
+    {
+        $fieldLayoutParam = 'fieldLayoutId';
+        if ($field instanceof Variants) {
+            $fieldLayoutParam = 'variantFieldLayoutId';
+        }
+
+        // The field will be null e.g. when importing into a structure product type, and there's the option to select a parent
+        // the parent is serviced by the field markup too, but it doesn't tie into a custom field per se;
+        if ($field === null) {
+            $productType = CommercePlugin::getInstance()->getProductTypes()->getProductTypeById($feed->elementGroup[ProductElement::class]['productType']);
+            if (!$productType) {
+                return FieldHelper::getAllUniqueIdFields();
+            }
+
+            $fieldLayout = null;
+            if ($productType->$fieldLayoutParam) {
+                $fieldLayout = Craft::$app->getFields()->getLayoutById($productType->$fieldLayoutParam);
+            }
+
+            if (!$fieldLayout) {
+                return FieldHelper::getAllUniqueIdFields();
+            }
+
+            return array_filter(
+                $fieldLayout->getCustomFields(),
+                fn($field) => FieldHelper::fieldCanBeUniqueId($field)
+            );
+        } else {
+            // if the Commerce Products field has only custom sources - we have no choice but return all the field
+            if (FieldHelper::fieldHasOnlyCustomSources($field)) {
+                return FieldHelper::getAllUniqueIdFields();
+            }
+
+            // deal with the native sources - sections
+            $productTypes = FieldHelper::getCommerceProductSourcesByField($field);
+
+            $allowedFields = [];
+            $productTypes = Collection::make($productTypes)->keyBy('id');
+
+            foreach ($productTypes as $productType) {
+                if ($productType->$fieldLayoutParam) {
+                    $fieldLayout = Craft::$app->getFields()->getLayoutById($productType->$fieldLayoutParam);
+                    if ($fieldLayout) {
+                        $allowedFields = [...$allowedFields, ...$fieldLayout->getCustomFields()];
+                    }
+                }
+            }
+
+            // if there's a custom source in the mix, we should add all the fields too
+            $customSources = [];
+            if (is_array($field['sources'])) {
+                $customSources = array_filter($field['sources'], (fn(string $source) => str_starts_with($source, 'custom:')));
+            }
+
+            if (!empty($customSources)) {
+                $allowedFields = [...$allowedFields, ...Craft::$app->getFields()->getAllFields()];
+            }
+
+            return array_filter($allowedFields, fn($field) => FieldHelper::fieldCanBeUniqueId($field));
+        }
     }
 }

--- a/src/helpers/FieldHelper.php
+++ b/src/helpers/FieldHelper.php
@@ -121,6 +121,7 @@ class FieldHelper
             foreach ($field->sources as $source) {
                 [, $uid] = explode(':', $source);
 
+                /** @phpstan-ignore-next-line */
                 $productType = CommercePlugin::getInstance()->getProductTypes()->getProductTypeByUid($uid);
                 // only add to product types, if this was a section that we were able to retrieve (native section's uid)
                 // https://github.com/craftcms/feed-me/issues/1186
@@ -129,6 +130,7 @@ class FieldHelper
                 }
             }
         } elseif ($field->sources === '*') {
+            /** @phpstan-ignore-next-line */
             $sources = CommercePlugin::getInstance()->getProductTypes()->getAllProductTypes();
         }
 

--- a/src/helpers/FieldHelper.php
+++ b/src/helpers/FieldHelper.php
@@ -3,6 +3,7 @@
 namespace craft\feedme\helpers;
 
 use Craft;
+use craft\commerce\Plugin as CommercePlugin;
 use craft\elements\User as UserElement;
 use craft\fields\Checkboxes;
 use craft\fields\Color;
@@ -108,6 +109,32 @@ class FieldHelper
         return Craft::$app->tags->getTagGroupByUid($uid);
     }
 
+    public static function getCommerceProductSourcesByField($field): ?array
+    {
+        $sources = [];
+
+        if (!$field) {
+            return null;
+        }
+
+        if (is_array($field->sources)) {
+            foreach ($field->sources as $source) {
+                [, $uid] = explode(':', $source);
+
+                $productType = CommercePlugin::getInstance()->getProductTypes()->getProductTypeByUid($uid);
+                // only add to product types, if this was a section that we were able to retrieve (native section's uid)
+                // https://github.com/craftcms/feed-me/issues/1186
+                if ($productType) {
+                    $sources[] = $productType;
+                }
+            }
+        } elseif ($field->sources === '*') {
+            $sources = CommercePlugin::getInstance()->getProductTypes()->getAllProductTypes();
+        }
+
+        return $sources;
+    }
+
     //
     // Helper functions for element fields in getting their inner-element field layouts
     //
@@ -129,6 +156,8 @@ class FieldHelper
             }
         } elseif ($type === 'craft\fields\Tags') {
             $source = static::getTagSourcesByField($field);
+        } elseif ($type === 'craft\commerce\fields\Products' || $type === 'craft\commerce\fields\Variants') {
+            $source = static::getCommerceProductSourcesByField($field)[0] ?? null;
         }
 
         if (!$source || !$source->fieldLayoutId) {

--- a/src/helpers/FieldHelper.php
+++ b/src/helpers/FieldHelper.php
@@ -160,11 +160,16 @@ class FieldHelper
             $source = static::getCommerceProductSourcesByField($field)[0] ?? null;
         }
 
-        if (!$source || !$source->fieldLayoutId) {
+        $fieldLayoutParam = 'fieldLayoutId';
+        if ($type === 'craft\commerce\fields\Variants') {
+            $fieldLayoutParam = 'variantFieldLayoutId';
+        }
+
+        if (!$source || !$source->$fieldLayoutParam) {
             return null;
         }
 
-        if (($fieldLayout = Craft::$app->getFields()->getLayoutById($source->fieldLayoutId)) !== null) {
+        if (($fieldLayout = Craft::$app->getFields()->getLayoutById($source->$fieldLayoutParam)) !== null) {
             return ArrayHelper::merge($fieldLayout->getCustomFields(), $fieldLayout->getAvailableNativeFields());
         }
 

--- a/src/templates/_includes/fields/commerce_products.html
+++ b/src/templates/_includes/fields/commerce_products.html
@@ -32,6 +32,7 @@
             { value: 'title', label: 'Title'|t('feed-me') },
             { value: 'id', label: 'ID'|t('feed-me') },
             { value: 'slug', label: 'Slug'|t('feed-me') },
+            { value: 'defaultSku', label: 'Default SKU'|t('feed-me') },
         ] %}
 
         {% if field is defined and field is not empty %}

--- a/src/templates/_includes/fields/commerce_products.html
+++ b/src/templates/_includes/fields/commerce_products.html
@@ -28,15 +28,23 @@
     <div class="element-match">
         <span>{{ 'Data provided for this product is:'|t('feed-me') }}</span>
 
+        {% set matchAttributes = [
+            { value: 'title', label: 'Title'|t('feed-me') },
+            { value: 'id', label: 'ID'|t('feed-me') },
+            { value: 'slug', label: 'Slug'|t('feed-me') },
+        ] %}
+
+        {% if field is defined and field is not empty %}
+            {% set matchAttributes = matchAttributes|merge(craft.feedme.getRelationFieldMatchOptions(className(field), feed, field)) %}
+        {% else %}
+            {% set matchAttributes = matchAttributes|merge(craft.feedme.getRelationFieldMatchOptions('craft\\commerce\\fields\\Products', feed, null)) %}
+        {% endif %}
+
         {{ forms.selectField({
             name: 'options[match]',
             class: '',
             value: hash_get(feed.fieldMapping, optionsPath ~ '.match') ?: '',
-            options: [
-                { value: 'title', label: 'Title'|t('feed-me') },
-                { value: 'id', label: 'ID'|t('feed-me') },
-                { value: 'slug', label: 'Slug'|t('feed-me') },
-            ],
+            options: matchAttributes,
         }) }}
     </div>
 {% endblock %}

--- a/src/templates/_includes/fields/commerce_variants.html
+++ b/src/templates/_includes/fields/commerce_variants.html
@@ -28,15 +28,23 @@
     <div class="element-match">
         <span>{{ 'Data provided for this variant is:'|t('feed-me') }}</span>
 
+        {% set matchAttributes = [
+            { value: 'title', label: 'Title'|t('feed-me') },
+            { value: 'id', label: 'ID'|t('feed-me') },
+            { value: 'sku', label: 'SKU'|t('feed-me') },
+        ] %}
+
+        {% if field is defined and field is not empty %}
+            {% set matchAttributes = matchAttributes|merge(craft.feedme.getRelationFieldMatchOptions(className(field), feed, field)) %}
+        {% else %}
+            {% set matchAttributes = matchAttributes|merge(craft.feedme.getRelationFieldMatchOptions('craft\\commerce\\fields\\Variants', feed, null)) %}
+        {% endif %}
+
         {{ forms.selectField({
             name: 'options[match]',
             class: '',
             value: hash_get(feed.fieldMapping, optionsPath ~ '.match') ?: '',
-            options: [
-                { value: 'title', label: 'Title'|t('feed-me') },
-                { value: 'id', label: 'ID'|t('feed-me') },
-                { value: 'sku', label: 'SKU'|t('feed-me') },
-            ],
+            options: matchAttributes,
         }) }}
     </div>
 {% endblock %}

--- a/src/web/twig/variables/FeedMeVariable.php
+++ b/src/web/twig/variables/FeedMeVariable.php
@@ -3,6 +3,8 @@
 namespace craft\feedme\web\twig\variables;
 
 use Craft;
+use craft\commerce\fields\Products;
+use craft\commerce\fields\Variants;
 use craft\feedme\helpers\FieldHelper;
 use craft\feedme\models\FeedModel;
 use craft\feedme\Plugin;
@@ -244,6 +246,8 @@ class FeedMeVariable extends ServiceLocator
             Categories::class => \craft\feedme\fields\Categories::class,
             Entries::class => \craft\feedme\fields\Entries::class,
             Users::class => \craft\feedme\fields\Users::class,
+            // yes, this mapping is intentional because the logic in getMatchFields() is almost the same for products and variants
+            Products::class, Variants::class => \craft\feedme\fields\CommerceProducts::class,
             default => null,
         };
 

--- a/src/web/twig/variables/FeedMeVariable.php
+++ b/src/web/twig/variables/FeedMeVariable.php
@@ -247,6 +247,7 @@ class FeedMeVariable extends ServiceLocator
             Entries::class => \craft\feedme\fields\Entries::class,
             Users::class => \craft\feedme\fields\Users::class,
             // yes, this mapping is intentional because the logic in getMatchFields() is almost the same for products and variants
+            /** @phpstan-ignore-next-line */
             Products::class, Variants::class => \craft\feedme\fields\CommerceProducts::class,
             default => null,
         };


### PR DESCRIPTION
### Description
Builds on #1717.

This PR adds custom field mapping support for Commerce Products and Variants relation fields, so they work like other relation fields, e.g. Entries, Categories, etc.

It also adds the ability to match Commerce Products values based on a default SKU.


### Related issues
#902 
