### PR TITLE
Counting number addresses to import

### DIFF
--- a/src/fields/Addresses.php
+++ b/src/fields/Addresses.php
@@ -134,7 +134,7 @@ class Addresses extends Field implements FieldInterface
                 $node = Hash::get($fieldInfo, 'node');
                 if ($node) {
                     $nodeSegments = explode('/', $node);
-                    $regex = '^' . str_replace('//', '/', implode('\/\d?\/', $nodeSegments)) . '$';
+                    $regex = '^' . str_replace('//', '/', implode('\/(?:\d+\/)?', $nodeSegments)) . '$';
                     $matches = preg_grep('/' . $regex . '/', array_keys($this->feedData));
                     if (count($matches) > $noAddresses) {
                         $noAddresses = count($matches);


### PR DESCRIPTION
### Description
This PR adjusts the regex that counts number of addresses to import, so that pattern like `addresses/address/label` gets a match.

The bug was that if there wasn't any digits in between the path segments, the regex would only match when there were double slashes (`addresses//address//label`).

It also now accounts for numbers that are more than single digit.

### Related issues
#1715
