### PR TITLE
Bugfix/1716 feed import queue job and empty feed

### DIFF
--- a/src/queue/jobs/FeedImport.php
+++ b/src/queue/jobs/FeedImport.php
@@ -154,7 +154,8 @@ class FeedImport extends BaseBatchedJob implements RetryableJobInterface
         $data = array_filter((array)$this->data());
 
         if (empty($data)) {
-            Plugin::info('No feed items to process.');
+            Plugin::info("No feed items to process.");
+            $this->maybeProcessSequencedFeeds($this->feed->id);
             return;
         }
       

--- a/src/queue/jobs/FeedImport.php
+++ b/src/queue/jobs/FeedImport.php
@@ -153,6 +153,8 @@ class FeedImport extends BaseBatchedJob implements RetryableJobInterface
         $processService = Plugin::$plugin->getProcess();
         $data = array_filter((array)$this->data());
 
+        // we want to set this early (before EVENT_BEFORE_PROCESS_FEED event), or the logging won't be accurate in case there's no data
+        Plugin::$feedName = $this->feed->name;
         if (empty($data)) {
             Plugin::info("No feed items to process.");
             $this->maybeProcessSequencedFeeds($this->feed->id);


### PR DESCRIPTION
### Description
Fixes an issue where, if you queued up multiple feeds and one of them didn’t have any data, the feeds after it wouldn’t get processed.
It also fixes an issue where logging would get the previous feed’s name in such cases.


### Related issues
#1716 
#1725 