### PR TITLE
when getting elementIDs, search through the site we used to find elements in the first place

### DIFF
--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -233,7 +233,11 @@ class Entries extends Field implements FieldInterface
         // https://github.com/craftcms/feed-me/issues/1418
         if ($foundElements && $maintainHierarchy && Plugin::$plugin->service->getConfig('compareContent', $this->feed['id'])) {
             // get elements by IDs
-            $elements = EntryElement::find()->id($foundElements)->siteId($criteria['siteId'])->all();
+            $query = EntryElement::find()->id($foundElements);
+            if (Craft::$app->getIsMultiSite()) {
+                $query->siteId = $criteria['siteId'] ?? Craft::$app->getSites()->getCurrentSite()->id;
+            }
+            $elements = $query->all();
             Craft::$app->getStructures()->fillGapsInElements($elements);
             $foundElements = array_map(fn($element) => $element->id, $elements);
         }

--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -233,7 +233,7 @@ class Entries extends Field implements FieldInterface
         // https://github.com/craftcms/feed-me/issues/1418
         if ($foundElements && $maintainHierarchy && Plugin::$plugin->service->getConfig('compareContent', $this->feed['id'])) {
             // get elements by IDs
-            $elements = EntryElement::find()->id($foundElements)->site('*')->preferSites([$targetSiteId])->all();
+            $elements = EntryElement::find()->id($foundElements)->siteId($criteria['siteId'])->all();
             Craft::$app->getStructures()->fillGapsInElements($elements);
             $foundElements = array_map(fn($element) => $element->id, $elements);
         }

--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -233,7 +233,7 @@ class Entries extends Field implements FieldInterface
         // https://github.com/craftcms/feed-me/issues/1418
         if ($foundElements && $maintainHierarchy && Plugin::$plugin->service->getConfig('compareContent', $this->feed['id'])) {
             // get elements by IDs
-            $elements = EntryElement::find()->id($foundElements)->all();
+            $elements = EntryElement::find()->id($foundElements)->site('*')->preferSites([$targetSiteId])->all();
             Craft::$app->getStructures()->fillGapsInElements($elements);
             $foundElements = array_map(fn($element) => $element->id, $elements);
         }


### PR DESCRIPTION
### Description
Fixes an issue where importing into an Entries field with `maintainHierarchy` enabled would lose previously found entries if they existed on a site other than the current one.

Similar code also exists for the Categories field, but category elements always exist in all sites; this is not an issue there.


### Related issues
#1732 
