### PR TITLE
relation field performance improvements

### DIFF
--- a/src/fields/CalendarEvents.php
+++ b/src/fields/CalendarEvents.php
@@ -86,6 +86,22 @@ class CalendarEvents extends Field implements FieldInterface
             $typeIds = null;
         }
 
+        // In multi-site, there's currently no way to query across all sites - we use the current site
+        // See https://github.com/craftcms/cms/issues/2854
+        if (Craft::$app->getIsMultiSite()) {
+            if ($targetSiteId) {
+                $criteria['siteId'] = Craft::$app->getSites()->getSiteByUid($targetSiteId)->id;
+            } elseif ($feedSiteId) {
+                $criteria['siteId'] = $feedSiteId;
+            } else {
+                $criteria['siteId'] = Craft::$app->getSites()->getCurrentSite()->id;
+            }
+        }
+
+        $criteria['status'] = null;
+        $criteria['typeId'] = $typeIds;
+        $criteria['limit'] = $limit;
+
         $foundElements = [];
 
         foreach ($value as $dataValue) {
@@ -109,21 +125,6 @@ class CalendarEvents extends Field implements FieldInterface
 
             $query = EventElement::find();
 
-            // In multi-site, there's currently no way to query across all sites - we use the current site
-            // See https://github.com/craftcms/cms/issues/2854
-            if (Craft::$app->getIsMultiSite()) {
-                if ($targetSiteId) {
-                    $criteria['siteId'] = Craft::$app->getSites()->getSiteByUid($targetSiteId)->id;
-                } elseif ($feedSiteId) {
-                    $criteria['siteId'] = $feedSiteId;
-                } else {
-                    $criteria['siteId'] = Craft::$app->getSites()->getCurrentSite()->id;
-                }
-            }
-
-            $criteria['status'] = null;
-            $criteria['typeId'] = $typeIds;
-            $criteria['limit'] = $limit;
             // prep the $dataValue for matching
             $criteria[$match] = DataHelper::prepValueForElementMatch($dataValue);
 

--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -111,6 +111,25 @@ class Categories extends Field implements FieldInterface
             $groupId = Db::idByUid('{{%categorygroups}}', $groupUid);
         }
 
+        // In multi-site, there's currently no way to query across all sites - we use the current site
+        // See https://github.com/craftcms/cms/issues/2854
+        if (Craft::$app->getIsMultiSite()) {
+            if ($targetSiteId) {
+                $criteria['siteId'] = Craft::$app->getSites()->getSiteByUid($targetSiteId)->id;
+            } elseif ($feedSiteId) {
+                $criteria['siteId'] = $feedSiteId;
+            } else {
+                $criteria['siteId'] = Craft::$app->getSites()->getCurrentSite()->id;
+            }
+        }
+
+        if ($groupId) {
+            $criteria['groupId'] = $groupId;
+        }
+
+        $criteria['status'] = null;
+        $criteria['limit'] = $limit;
+
         $foundElements = [];
 
         foreach ($value as $dataValue) {
@@ -135,24 +154,6 @@ class Categories extends Field implements FieldInterface
 
             $query = CategoryElement::find();
 
-            // In multi-site, there's currently no way to query across all sites - we use the current site
-            // See https://github.com/craftcms/cms/issues/2854
-            if (Craft::$app->getIsMultiSite()) {
-                if ($targetSiteId) {
-                    $criteria['siteId'] = Craft::$app->getSites()->getSiteByUid($targetSiteId)->id;
-                } elseif ($feedSiteId) {
-                    $criteria['siteId'] = $feedSiteId;
-                } else {
-                    $criteria['siteId'] = Craft::$app->getSites()->getCurrentSite()->id;
-                }
-            }
-
-            if ($groupId) {
-                $criteria['groupId'] = $groupId;
-            }
-
-            $criteria['status'] = null;
-            $criteria['limit'] = $limit;
             // prep the $dataValue for matching
             $criteria[$match] = DataHelper::prepValueForElementMatch($dataValue);
 

--- a/src/fields/CommerceProducts.php
+++ b/src/fields/CommerceProducts.php
@@ -90,6 +90,22 @@ class CommerceProducts extends Field implements FieldInterface
             $typeIds = null;
         }
 
+        // In multi-site, there's currently no way to query across all sites - we use the current site
+        // See https://github.com/craftcms/cms/issues/2854
+        if (Craft::$app->getIsMultiSite()) {
+            if ($targetSiteId) {
+                $criteria['siteId'] = Craft::$app->getSites()->getSiteByUid($targetSiteId)->id;
+            } elseif ($feedSiteId) {
+                $criteria['siteId'] = $feedSiteId;
+            } else {
+                $criteria['siteId'] = Craft::$app->getSites()->getCurrentSite()->id;
+            }
+        }
+
+        $criteria['status'] = null;
+        $criteria['typeId'] = $typeIds;
+        $criteria['limit'] = $limit;
+
         $foundElements = [];
 
         foreach ($value as $dataValue) {
@@ -114,21 +130,6 @@ class CommerceProducts extends Field implements FieldInterface
 
             $query = ProductElement::find();
 
-            // In multi-site, there's currently no way to query across all sites - we use the current site
-            // See https://github.com/craftcms/cms/issues/2854
-            if (Craft::$app->getIsMultiSite()) {
-                if ($targetSiteId) {
-                    $criteria['siteId'] = Craft::$app->getSites()->getSiteByUid($targetSiteId)->id;
-                } elseif ($feedSiteId) {
-                    $criteria['siteId'] = $feedSiteId;
-                } else {
-                    $criteria['siteId'] = Craft::$app->getSites()->getCurrentSite()->id;
-                }
-            }
-
-            $criteria['status'] = null;
-            $criteria['typeId'] = $typeIds;
-            $criteria['limit'] = $limit;
             // prep the $dataValue for matching
             $criteria[$match] = DataHelper::prepValueForElementMatch($dataValue);
 

--- a/src/fields/CommerceVariants.php
+++ b/src/fields/CommerceVariants.php
@@ -90,6 +90,22 @@ class CommerceVariants extends Field implements FieldInterface
             $typeIds = null;
         }
 
+        // In multi-site, there's currently no way to query across all sites - we use the current site
+        // See https://github.com/craftcms/cms/issues/2854
+        if (Craft::$app->getIsMultiSite()) {
+            if ($targetSiteId) {
+                $criteria['siteId'] = Craft::$app->getSites()->getSiteByUid($targetSiteId)->id;
+            } elseif ($feedSiteId) {
+                $criteria['siteId'] = $feedSiteId;
+            } else {
+                $criteria['siteId'] = Craft::$app->getSites()->getCurrentSite()->id;
+            }
+        }
+
+        $criteria['status'] = null;
+        $criteria['typeId'] = $typeIds;
+        $criteria['limit'] = $limit;
+
         $foundElements = [];
 
         foreach ($value as $dataValue) {
@@ -114,21 +130,6 @@ class CommerceVariants extends Field implements FieldInterface
 
             $query = VariantElement::find();
 
-            // In multi-site, there's currently no way to query across all sites - we use the current site
-            // See https://github.com/craftcms/cms/issues/2854
-            if (Craft::$app->getIsMultiSite()) {
-                if ($targetSiteId) {
-                    $criteria['siteId'] = Craft::$app->getSites()->getSiteByUid($targetSiteId)->id;
-                } elseif ($feedSiteId) {
-                    $criteria['siteId'] = $feedSiteId;
-                } else {
-                    $criteria['siteId'] = Craft::$app->getSites()->getCurrentSite()->id;
-                }
-            }
-
-            $criteria['status'] = null;
-            $criteria['typeId'] = $typeIds;
-            $criteria['limit'] = $limit;
             // prep the $dataValue for matching
             $criteria[$match] = DataHelper::prepValueForElementMatch($dataValue);
 

--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -131,6 +131,21 @@ class Entries extends Field implements FieldInterface
             $sectionIds = null;
         }
 
+        // In multi-site, there's currently no way to query across all sites - we use the current site
+        // See https://github.com/craftcms/cms/issues/2854
+        if (Craft::$app->getIsMultiSite()) {
+            if ($targetSiteId) {
+                $criteria['siteId'] = Craft::$app->getSites()->getSiteByUid($targetSiteId)->id;
+            } elseif ($feedSiteId) {
+                $criteria['siteId'] = $feedSiteId;
+            } else {
+                $criteria['siteId'] = Craft::$app->getSites()->getCurrentSite()->id;
+            }
+        }
+
+        $criteria['status'] = null;
+        $criteria['limit'] = $limit;
+
         $foundElements = [];
 
         foreach ($value as $dataValue) {
@@ -155,20 +170,6 @@ class Entries extends Field implements FieldInterface
 
             $query = EntryElement::find();
 
-            // In multi-site, there's currently no way to query across all sites - we use the current site
-            // See https://github.com/craftcms/cms/issues/2854
-            if (Craft::$app->getIsMultiSite()) {
-                if ($targetSiteId) {
-                    $criteria['siteId'] = Craft::$app->getSites()->getSiteByUid($targetSiteId)->id;
-                } elseif ($feedSiteId) {
-                    $criteria['siteId'] = $feedSiteId;
-                } else {
-                    $criteria['siteId'] = Craft::$app->getSites()->getCurrentSite()->id;
-                }
-            }
-
-            $criteria['status'] = null;
-            $criteria['limit'] = $limit;
             // prep the $dataValue for matching
             $criteria[$match] = DataHelper::prepValueForElementMatch($dataValue);
 

--- a/src/fields/Tags.php
+++ b/src/fields/Tags.php
@@ -89,6 +89,22 @@ class Tags extends Field implements FieldInterface
         [, $groupUid] = explode(':', $source);
         $groupId = Db::idByUid('{{%taggroups}}', $groupUid);
 
+        // In multi-site, there's currently no way to query across all sites - we use the current site
+        // See https://github.com/craftcms/cms/issues/2854
+        if (Craft::$app->getIsMultiSite()) {
+            if ($targetSiteId) {
+                $criteria['siteId'] = Craft::$app->getSites()->getSiteByUid($targetSiteId)->id;
+            } elseif ($feedSiteId) {
+                $criteria['siteId'] = $feedSiteId;
+            } else {
+                $criteria['siteId'] = Craft::$app->getSites()->getCurrentSite()->id;
+            }
+        }
+
+        $criteria['status'] = null;
+        $criteria['groupId'] = $groupId;
+        $criteria['limit'] = $limit;
+
         $foundElements = [];
 
         foreach ($value as $dataValue) {
@@ -112,21 +128,6 @@ class Tags extends Field implements FieldInterface
 
             $query = TagElement::find();
 
-            // In multi-site, there's currently no way to query across all sites - we use the current site
-            // See https://github.com/craftcms/cms/issues/2854
-            if (Craft::$app->getIsMultiSite()) {
-                if ($targetSiteId) {
-                    $criteria['siteId'] = Craft::$app->getSites()->getSiteByUid($targetSiteId)->id;
-                } elseif ($feedSiteId) {
-                    $criteria['siteId'] = $feedSiteId;
-                } else {
-                    $criteria['siteId'] = Craft::$app->getSites()->getCurrentSite()->id;
-                }
-            }
-
-            $criteria['status'] = null;
-            $criteria['groupId'] = $groupId;
-            $criteria['limit'] = $limit;
             // prep the $dataValue for matching
             $criteria[$match] = DataHelper::prepValueForElementMatch($dataValue);
 


### PR DESCRIPTION
### Description
While working on fixing some bugs, I noticed that we’re setting most relation field criteria for every value that’s passed into the field. While correct and desired for some criteria, there are a bunch that don’t depend on the value and can be set once per field.

For example, we don’t have to check whether the app is multisite and determine the site ID to use in the query for every value. This parameter depends on the field’s settings, so we can set it once and reuse it for all the values imported into the field.


### Related issues
n/a
