### PR TITLE
show the log timestamp in user's timezone + show timezone

### DIFF
--- a/src/services/Logs.php
+++ b/src/services/Logs.php
@@ -8,7 +8,6 @@ use craft\db\Query;
 use craft\feedme\Plugin;
 use craft\helpers\App;
 use craft\helpers\DateTimeHelper;
-use craft\helpers\Db;
 use craft\helpers\Json;
 use Exception;
 use Illuminate\Support\Collection;

--- a/src/services/Logs.php
+++ b/src/services/Logs.php
@@ -7,6 +7,7 @@ use craft\base\Component;
 use craft\db\Query;
 use craft\feedme\Plugin;
 use craft\helpers\App;
+use craft\helpers\DateTimeHelper;
 use craft\helpers\Db;
 use craft\helpers\Json;
 use Exception;
@@ -172,7 +173,7 @@ class Logs extends Component
             }
             $log = [
                 'type' => self::logLevelName($row['level']),
-                'date' => Db::prepareDateForDb($row['log_time']),
+                'date' => DateTimeHelper::toDateTime($row['log_time']),
                 'message' => $message,
                 'key' => $key,
             ];

--- a/src/templates/logs/index.html
+++ b/src/templates/logs/index.html
@@ -70,7 +70,7 @@
 
                         <td data-title="{{ 'Timestamp'|t('feed-me') }}">
                             <code>
-                                {{ logEntry.date|date('short') ~ ' ' ~ logEntry.date|time('short') }}
+                                {{ logEntry.date|datetime('short', withTimeZone: true) }}
                             </code>
                         </td>
                     </tr>


### PR DESCRIPTION
### Description
Shows the log’s timestamp in the user’s preferred timezone (system timezone or user’s settings) and shows the timezone abbreviation with it. This now aligns with how the CMS displays dates in the Control Panel.

Before:
<img width="971" height="505" alt="Screenshot 2026-05-26 at 17 00 55" src="https://github.com/user-attachments/assets/5b88f0f6-4c6f-4e03-8606-bf35e9f648b6" />

After:
<img width="964" height="589" alt="Screenshot 2026-05-26 at 17 00 39" src="https://github.com/user-attachments/assets/da302f46-1aa1-48d8-8862-0c10cd278871" />


### Related issues
#1734
